### PR TITLE
Tune streaming chunk size for optimal playback

### DIFF
--- a/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
@@ -422,8 +422,8 @@ void processMetadata(WiFiClientSecure& client, uint32_t length) {
 void processPCM(WiFiClientSecure& client, uint32_t length) {
   Serial.printf("[PCM] Streaming %d bytes, Free heap: %d\n", length, ESP.getFreeHeap());
 
-  // ストリーミング再生用のバッファ（32KB）
-  const size_t STREAM_CHUNK_SIZE = 32768;  // 32KB = 約0.34秒分の音声
+  // ストリーミング再生用のバッファ（64KB）
+  const size_t STREAM_CHUNK_SIZE = 65536;  // 64KB = 約0.68秒分の音声
   uint32_t remaining = length;
   uint32_t totalPlayed = 0;
 

--- a/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
@@ -422,8 +422,8 @@ void processMetadata(WiFiClientSecure& client, uint32_t length) {
 void processPCM(WiFiClientSecure& client, uint32_t length) {
   Serial.printf("[PCM] Streaming %d bytes, Free heap: %d\n", length, ESP.getFreeHeap());
 
-  // ストリーミング再生用の小さいバッファ（8KB）
-  const size_t STREAM_CHUNK_SIZE = 8192;  // 8KB = 約0.085秒分の音声
+  // ストリーミング再生用のバッファ（32KB）
+  const size_t STREAM_CHUNK_SIZE = 32768;  // 32KB = 約0.34秒分の音声
   uint32_t remaining = length;
   uint32_t totalPlayed = 0;
 


### PR DESCRIPTION
## Summary
- Increased streaming chunk size from 8KB → 64KB to reduce audio choppiness
- Tested 32KB and 64KB, settled on 64KB for best balance

## Changes
- `STREAM_CHUNK_SIZE`: 8192 → 65536 bytes (約0.68秒分の音声)
- Reduces processing overhead by handling larger chunks at once
- Minimizes gaps between chunk transitions

## Testing Results
- 8KB: Fast response but choppy playback
- 32KB: Improved but still occasional choppiness
- 64KB: Much smoother, occasional choppiness under network delays

## Next Steps
- v1.4 will implement double-buffering with FreeRTOS tasks to eliminate remaining choppiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)