### PR TITLE
Update TTS model to gpt-4o-mini-tts-2025-03-20

### DIFF
--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -46,7 +46,7 @@
       llmVendor: "openai",
       llmModel:  "gpt-4.1-mini",
       ttsVendor: "openai",
-      ttsModel:  "gpt-4o-mini-tts",
+      ttsModel:  "gpt-4o-mini-tts-2025-03-20",
     },
     // LLM: OpenAI / TTS: Google Cloud Text-to-Speech
     Google: {


### PR DESCRIPTION
## Summary
- Update TTS model from `gpt-4o-mini-tts` to `gpt-4o-mini-tts-2025-03-20`

## Background
最新版のTTSモデルに不備があり、レスポンスが遅くなっていたため、安定版の `gpt-4o-mini-tts-2025-03-20` に変更。

## Changes
- backend/toytalk-api-stream-for-esp32-lambda/index.mjs:49
  - `ttsModel: "gpt-4o-mini-tts"` → `ttsModel: "gpt-4o-mini-tts-2025-03-20"`

## Test plan
- [x] Verify TTS response speed improves
- [x] Confirm audio quality remains good

🤖 Generated with [Claude Code](https://claude.com/claude-code)