### PR TITLE
Add ElevenLabs TTS and improve multi-provider TTS architecture

### DIFF
--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -354,13 +354,17 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       try {
         let pcmBuffer;
         if (cfg.ttsVendor === "openai") {
-          pcmBuffer = await ttsBufferOpenAI(t, voice, cfg.ttsModel);
+          const voiceName = voice === "default" ? "nova" : voice;
+          pcmBuffer = await ttsBufferOpenAI(t, voiceName, cfg.ttsModel);
         } else if (cfg.ttsVendor === "google") {
-          pcmBuffer = await ttsBufferGoogle(t, { voiceName: "ja-JP-Neural2-C" });
+          const voiceName = voice === "default" ? "ja-JP-Neural2-C" : voice;  // 男性
+          pcmBuffer = await ttsBufferGoogle(t, { voiceName });
         } else if (cfg.ttsVendor === "gemini") {
-          pcmBuffer = await ttsBufferGemini(t, { model: cfg.ttsModel, voiceName: "Kore" });
+          const voiceName = voice === "default" ? "Kore" : voice;
+          pcmBuffer = await ttsBufferGemini(t, { model: cfg.ttsModel, voiceName });
         } else if (cfg.ttsVendor === "elevenlabs") {
-          pcmBuffer = await ttsBufferElevenLabs(t, { model: cfg.ttsModel });
+          const voiceId = voice === "default" ? "hMK7c1GPJmptCzI4bQIu" : voice;  // Sameno（子供向け）
+          pcmBuffer = await ttsBufferElevenLabs(t, { model: cfg.ttsModel, voiceId });
         } else {
           throw new Error("Unknown ttsVendor");
         }

--- a/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
@@ -582,7 +582,7 @@ void sendToLambdaAndPlay(const String& text) {
   messagesJson += "]";
 
   String payload =
-    "{\"model\":\"Google\",\"voice\":\"nova\","
+    "{\"model\":\"Gemini\",\"voice\":\"nova\","
     "\"messages\":" + messagesJson + "}";
 
   Serial.printf("📝 History count: %d\n", historyCount);

--- a/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
@@ -88,6 +88,13 @@ int historyCount = 0;
 // ==== 音量調整 ====
 const float VOLUME = 1.0;
 
+// ==== TTS設定（DynamoDB連携予定）====
+// TTS_PROVIDER候補: "OpenAI" / "Google" / "Gemini" / "ElevenLabs"
+const char* TTS_PROVIDER = "ElevenLabs";
+// TTS_CHARACTER: "default"の場合、各TTSのデフォルトキャラクターを使用
+// ElevenLabs: Sameno（子供向け）, OpenAI: nova, Google: ja-JP-Neural2-C, Gemini: Kore
+const char* TTS_CHARACTER = "default";
+
 // ==== メモリ診断関数 ====
 #if DEBUG_MEMORY
 void printMemoryStatus(const char* label) {
@@ -582,7 +589,7 @@ void sendToLambdaAndPlay(const String& text) {
   messagesJson += "]";
 
   String payload =
-    "{\"model\":\"Gemini\",\"voice\":\"nova\","
+    "{\"model\":\"" + String(TTS_PROVIDER) + "\",\"voice\":\"" + String(TTS_CHARACTER) + "\","
     "\"messages\":" + messagesJson + "}";
 
   Serial.printf("📝 History count: %d\n", historyCount);

--- a/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
@@ -86,7 +86,7 @@ Message conversationHistory[MAX_HISTORY * 2];
 int historyCount = 0;
 
 // ==== 音量調整 ====
-const float VOLUME = 1.5;
+const float VOLUME = 1.0;
 
 // ==== メモリ診断関数 ====
 #if DEBUG_MEMORY
@@ -582,7 +582,7 @@ void sendToLambdaAndPlay(const String& text) {
   messagesJson += "]";
 
   String payload =
-    "{\"model\":\"OpenAI\",\"voice\":\"nova\","
+    "{\"model\":\"ElevenLabs\",\"voice\":\"nova\","
     "\"messages\":" + messagesJson + "}";
 
   Serial.printf("📝 History count: %d\n", historyCount);

--- a/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v1.3/toytalk_demo_v1.3.ino
@@ -582,7 +582,7 @@ void sendToLambdaAndPlay(const String& text) {
   messagesJson += "]";
 
   String payload =
-    "{\"model\":\"ElevenLabs\",\"voice\":\"nova\","
+    "{\"model\":\"Google\",\"voice\":\"nova\","
     "\"messages\":" + messagesJson + "}";
 
   Serial.printf("📝 History count: %d\n", historyCount);


### PR DESCRIPTION
## Summary
- Add ElevenLabs TTS integration with Sameno voice (child-friendly anime voice)
- Optimize Google TTS with 20ms fade-in to eliminate click sound and switch to male voice
- Add Gemini TTS support with debug logging
- Add configurable TTS provider and character system for future DynamoDB integration

## Changes
### Backend (Lambda)
- Add `ttsBufferElevenLabs()` function with proper PCM output format
- Fix Google TTS click artifact with fade-in processing
- Add Gemini TTS with simplified calling pattern
- Remove unused functions: `pcm16ToWavBase64()`, `resolveGoogleTtsFromBody()`, `resolveGeminiTtsFromBody()` (~90 lines)
- Implement "default" character handling for each TTS provider

### ESP32 Firmware
- Add `TTS_PROVIDER` and `TTS_CHARACTER` configuration variables
- Prepare for future DynamoDB-based dynamic configuration

## Test plan
- [x] ElevenLabs TTS working with Sameno voice (raw PCM format)
- [x] Google TTS working with fade-in fix and male voice
- [x] Gemini TTS working with Kore voice
- [x] OpenAI TTS still working with nova voice
- [x] All providers output raw PCM (no MP3, no base64)
- [x] Configuration variables working correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)