### PR TITLE
Increase text segmentation limit to 100 chars in app Lambda

### DIFF
--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -8,7 +8,7 @@
 
   // ---- チューニング定数 ----
   const HEAD_MIN_CHARS = 24;      // 今回は使わない（ヘッドTTS無効）
-  const SEG_MAX_CHARS  = 48;
+  const SEG_MAX_CHARS  = 100;     // 文末で自然に区切るため増加（安全網として残す）
   const TTS_FORMAT     = "wav";
   const VOICE_DEFAULT  = "alloy";
   const DEBUG          = false;


### PR DESCRIPTION
## Summary
- `SEG_MAX_CHARS` を 48 → 100 に変更
- ESP32用Lambda（toytalk-api-stream-for-esp32-lambda）に合わせた値
- 句読点で自然に区切れるようになり、不自然な途中切れが減少

🤖 Generated with [Claude Code](https://claude.com/claude-code)