### PR TITLE
Add toy voice selection via DynamoDB and BLE device registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ yarn-error.log
 dist/
 **/build/
 *.zip
+bundle.mjs
+bundle.js
 
 # key
 *.env

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -25,6 +25,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Menu, Provider } from "react-native-paper";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useFocusEffect } from "@react-navigation/native";
+import { MODEL_MAP, ModelKey } from "@/constants/ModelMap";
 import AudioRecord from "react-native-audio-record";
 import Sound from "react-native-sound";
 
@@ -114,74 +115,10 @@ export default function Chat() {
   const pillRef = useRef<View>(null);
   const { width: SCREEN_W } = Dimensions.get("window");
 
-  const [submenuFor, setSubmenuFor] = useState<keyof typeof MODEL_MAP | null>(null);
+  const [submenuFor, setSubmenuFor] = useState<ModelKey | null>(null);
   const MENU_W = 240;
 
-  const MODEL_MAP = {
-    OpenAI: {
-      label: "OpenAI",
-      desc: "4o-mini-tts",
-      defaultVoice: "nova",
-      voices: {
-        alloy: { label: "Alloy – neutral male", vendorId: "alloy" },
-        nova: { label: "Nova – kind female", vendorId: "nova" },
-        verse: { label: "Verse – calm narrator", vendorId: "verse" },
-      },
-    },
-    Google: {
-      label: "Google",
-      desc: "Google TTS",
-      defaultVoice: "jaB",
-      voices: {
-        jaB: { label: "JP-B – soft female", vendorId: "ja-JP-Neural2-B" },
-        jaC: { label: "JP-C – soft male", vendorId: "ja-JP-Neural2-C" },
-      },
-    },
-    Gemini: {
-      label: "Gemini",
-      desc: "2.5 Flash TTS",
-      defaultVoice: "leda",
-      voices: {
-        leda: { label: "Leda – clear female", vendorId: "leda" },
-        puck: { label: "Puck – clear male", vendorId: "puck" },
-      },
-    },
-    ElevenLabs: {
-      label: "ElevenLabs",
-      desc: "Turbo v2.5",
-      defaultVoice: "sameno",
-      voices: {
-        sameno: { label: "Sameno", vendorId: "hMK7c1GPJmptCzI4bQIu" },
-      },
-    },
-    FishAudio: {
-      label: "Fish Audio (demo)",
-      desc: "Fish Audio TTS",
-      defaultVoice: "sansan",
-      voices: {
-        sansan: { label: "サンサン", vendorId: "15454ccda92d4246a821a5d8f9728fb9" },
-        pikachu: { label: "ピカチュウ", vendorId: "d940622bd99742c6b10ececd13c7ee1c" },
-        doraemon: { label: "ドラえもん", vendorId: "7ad5d736bec7410090caf00dd91db21f" },
-        conan: { label: "コナン", vendorId: "8481836597324f1697052575e2ca1a7e" },
-        tanjiro: { label: "竈門炭治郎", vendorId: "00948a6e032249199e4a2699f0e0828e" },
-        rengoku: { label: "煉獄杏寿郎", vendorId: "738068acdf0346d4ad15873cf582b9c9" },
-        muzan: { label: "鬼舞辻無惨", vendorId: "18833cce92cc42e682f68073177f0e8f" },
-        marine: { label: "マリン船長", vendorId: "b24f3e45d0fc49ee942eb00741d70316" },
-        frieren: { label: "フリーレン", vendorId: "5a7a3dec0d9c415db57e9a7ce2ecee51" },
-        fern: { label: "フェルン", vendorId: "1dac8f5fd50648388edfcb4ca6cfb378" },
-        misato: { label: "葛城ミサト", vendorId: "5ec124a55410453a9c56aae75d3ba4c0" },
-        makima: { label: "マキマ", vendorId: "028c4c7eb08c43358a3e30fef264ca0e" },
-        reze: { label: "レゼ", vendorId: "6fdaebea7db042129f03ecb0a57ea7b6" },
-        light: { label: "夜神月", vendorId: "4bc1d3d1fa60415f989b8e0b99f333e1" },
-        naoya: { label: "禪院直哉", vendorId: "028e1ae4ba6d4c039ce29726a694500e" },
-        miwa: { label: "美輪明宏", vendorId: "d0407bac2cd14321bdfb492fa16506d7" },
-        hiroyuki: { label: "ひろゆき", vendorId: "f59b9bff8c37434aafed363ca72d14dc" },
-        matsuko: { label: "マツコ・デラックス", vendorId: "e533e9f4f01d49dd8fb3e39dd3914464" },
-      },
-    },
-  } as const;
-
-  const [model, setModel] = useState<keyof typeof MODEL_MAP>("OpenAI");
+  const [model, setModel] = useState<ModelKey>("OpenAI");
   const [voiceKey, setVoiceKey] = useState<string>(MODEL_MAP[model].defaultVoice as string);
 
   // 会話履歴

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -11,81 +11,93 @@ import {
   ActivityIndicator,
   Platform,
   PermissionsAndroid,
+  ScrollView,
 } from "react-native";
 import { BleManager, Device } from "react-native-ble-plx";
 
 // BLE UUIDs (ESP32側と一致させる)
-const SERVICE_UUID = "12345678-1234-1234-1234-123456789abc";
-const CHAR_SSID_UUID = "12345678-1234-1234-1234-123456789ab1";
+const SERVICE_UUID       = "12345678-1234-1234-1234-123456789abc";
+const CHAR_SSID_UUID     = "12345678-1234-1234-1234-123456789ab1";
 const CHAR_PASSWORD_UUID = "12345678-1234-1234-1234-123456789ab2";
-const CHAR_COMMAND_UUID = "12345678-1234-1234-1234-123456789ab3";
-const CHAR_STATUS_UUID = "12345678-1234-1234-1234-123456789ab4";
+const CHAR_COMMAND_UUID  = "12345678-1234-1234-1234-123456789ab3";
+const CHAR_STATUS_UUID   = "12345678-1234-1234-1234-123456789ab4";
+const CHAR_MAC_UUID      = "12345678-1234-1234-1234-123456789ab5";
+
+const DEVICE_SETTING_URL = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
+const DEFAULT_VOICE_ID   = "elevenlabs_sameno";
 
 const bleManager = new BleManager();
 
 type ConnectionStatus = "disconnected" | "scanning" | "connecting" | "connected" | "configuring";
+type Screen = "home" | "device-settings" | "voice-select";
+
+type VoiceItem = {
+  voice_id: string;
+  label: string;
+  provider: string;
+  vendor_id: string;
+};
+
+type RegisteredDevice = {
+  device_id: string;
+  voice_id: string | null;
+  owner_id: string;
+};
 
 export default function Toy() {
-  const [status, setStatus] = useState<ConnectionStatus>("disconnected");
-  const [devices, setDevices] = useState<Device[]>([]);
-  const [connectedDevice, setConnectedDevice] = useState<Device | null>(null);
-  const [ssid, setSsid] = useState("");
-  const [password, setPassword] = useState("");
-  const [statusMessage, setStatusMessage] = useState("");
+  const [status, setStatus]                     = useState<ConnectionStatus>("disconnected");
+  const [bleDevices, setBleDevices]             = useState<Device[]>([]);
+  const [connectedDevice, setConnectedDevice]   = useState<Device | null>(null);
+  const [ssid, setSsid]                         = useState("");
+  const [password, setPassword]                 = useState("");
+  const [statusMessage, setStatusMessage]       = useState("");
+  const [screen, setScreen]                     = useState<Screen>("home");
+  const [deviceId, setDeviceId]                 = useState<string | null>(null);
+  const [registeredDevice, setRegisteredDevice] = useState<RegisteredDevice | null>(null);
+  const [voices, setVoices]                     = useState<VoiceItem[]>([]);
+  const [voicesLoading, setVoicesLoading]       = useState(false);
+  const [updatingVoice, setUpdatingVoice]       = useState(false);
 
   useEffect(() => {
-    // Androidの権限リクエスト
     if (Platform.OS === "android") {
       requestAndroidPermissions();
     }
-
     return () => {
-      // クリーンアップ
       bleManager.stopDeviceScan();
     };
   }, []);
 
   const requestAndroidPermissions = async () => {
     if (Platform.OS === "android" && Platform.Version >= 31) {
-      const granted = await PermissionsAndroid.requestMultiple([
+      await PermissionsAndroid.requestMultiple([
         PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
         PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
         PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION,
       ]);
-      console.log("Permissions:", granted);
     } else if (Platform.OS === "android") {
-      const granted = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION
-      );
-      console.log("Location permission:", granted);
+      await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION);
     }
   };
 
   const startScan = () => {
-    setDevices([]);
+    setBleDevices([]);
     setStatus("scanning");
     setStatusMessage("スキャン中...");
 
     bleManager.startDeviceScan(null, null, (error, device) => {
       if (error) {
-        console.error("Scan error:", error);
         setStatus("disconnected");
         setStatusMessage("スキャンエラー: " + error.message);
         return;
       }
-
-      if (device && device.name) {
-        // ToyTalk-Setupデバイスのみ表示
-        if (device.name.includes("ToyTalk")) {
-          setDevices((prev) => {
-            if (prev.find((d) => d.id === device.id)) return prev;
-            return [...prev, device];
-          });
-        }
+      if (device?.name?.includes("ToyTalk")) {
+        setBleDevices((prev) => {
+          if (prev.find((d) => d.id === device.id)) return prev;
+          return [...prev, device];
+        });
       }
     });
 
-    // 10秒後にスキャン停止
     setTimeout(() => {
       bleManager.stopDeviceScan();
       setStatus("disconnected");
@@ -108,55 +120,71 @@ export default function Toy() {
       const connected = await device.connect();
       await connected.discoverAllServicesAndCharacteristics();
 
+      // MACアドレスをCHAR_MACから読み取る
+      const macChar = await connected.readCharacteristicForService(SERVICE_UUID, CHAR_MAC_UUID);
+      const mac = macChar.value ? atob(macChar.value) : device.id;
+      setDeviceId(mac);
+
       setConnectedDevice(connected);
       setStatus("connected");
       setStatusMessage("接続完了！WiFi設定を入力してください");
 
-      // 状態通知を購読
       connected.monitorCharacteristicForService(
         SERVICE_UUID,
         CHAR_STATUS_UUID,
         (error, characteristic) => {
-          if (error) {
-            console.error("Monitor error:", error);
-            return;
-          }
+          if (error) return;
           if (characteristic?.value) {
-            const decoded = atob(characteristic.value);
-            console.log("Status from ESP32:", decoded);
-            handleStatusUpdate(decoded);
+            handleStatusUpdate(atob(characteristic.value), mac);
           }
         }
       );
 
-      // 切断検知
       connected.onDisconnected(() => {
         setConnectedDevice(null);
         setStatus("disconnected");
         setStatusMessage("切断されました");
       });
     } catch (error: any) {
-      console.error("Connection error:", error);
       setStatus("disconnected");
       setStatusMessage("接続エラー: " + error.message);
     }
   };
 
-  const handleStatusUpdate = (status: string) => {
-    switch (status) {
+  const handleStatusUpdate = async (bleStatus: string, mac: string) => {
+    switch (bleStatus) {
       case "CONNECTING":
         setStatusMessage("WiFi接続中...");
         break;
       case "CONNECTED":
-        setStatusMessage("✅ WiFi接続成功！");
-        Alert.alert("成功", "WiFi設定が完了しました");
+        setStatusMessage("WiFi接続成功！デバイスを登録中...");
+        await registerDevice(mac);
         break;
       case "FAILED":
-        setStatusMessage("❌ WiFi接続失敗");
+        setStatusMessage("WiFi接続失敗");
         Alert.alert("エラー", "WiFi接続に失敗しました。SSID/パスワードを確認してください。");
         break;
       default:
-        setStatusMessage(status);
+        setStatusMessage(bleStatus);
+    }
+  };
+
+  const registerDevice = async (mac: string) => {
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/devices`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ device_id: mac }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      // 登録後にデバイス情報を取得
+      const deviceRes = await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(mac)}`);
+      const deviceData = await deviceRes.json();
+      setRegisteredDevice(deviceData);
+      setStatusMessage("デバイス登録完了！");
+    } catch (e: any) {
+      setStatusMessage("デバイス登録エラー: " + e.message);
     }
   };
 
@@ -169,35 +197,14 @@ export default function Toy() {
       Alert.alert("エラー", "SSIDを入力してください");
       return;
     }
-
     try {
       setStatus("configuring");
       setStatusMessage("設定を送信中...");
-
-      // SSIDを送信
-      await connectedDevice.writeCharacteristicWithResponseForService(
-        SERVICE_UUID,
-        CHAR_SSID_UUID,
-        btoa(ssid)
-      );
-
-      // パスワードを送信
-      await connectedDevice.writeCharacteristicWithResponseForService(
-        SERVICE_UUID,
-        CHAR_PASSWORD_UUID,
-        btoa(password)
-      );
-
-      // 接続コマンドを送信
-      await connectedDevice.writeCharacteristicWithResponseForService(
-        SERVICE_UUID,
-        CHAR_COMMAND_UUID,
-        btoa("CONNECT")
-      );
-
+      await connectedDevice.writeCharacteristicWithResponseForService(SERVICE_UUID, CHAR_SSID_UUID, btoa(ssid));
+      await connectedDevice.writeCharacteristicWithResponseForService(SERVICE_UUID, CHAR_PASSWORD_UUID, btoa(password));
+      await connectedDevice.writeCharacteristicWithResponseForService(SERVICE_UUID, CHAR_COMMAND_UUID, btoa("CONNECT"));
       setStatusMessage("設定送信完了、WiFi接続を待機中...");
     } catch (error: any) {
-      console.error("Write error:", error);
       setStatus("connected");
       setStatusMessage("送信エラー: " + error.message);
     }
@@ -212,43 +219,171 @@ export default function Toy() {
     setStatusMessage("");
     setSsid("");
     setPassword("");
+    setRegisteredDevice(null);
+    setDeviceId(null);
   };
 
+  const openDeviceSettings = () => {
+    setScreen("device-settings");
+  };
+
+  const openVoiceSelect = async () => {
+    setVoicesLoading(true);
+    setScreen("voice-select");
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/voices`);
+      const data = await res.json();
+      setVoices(data.voices ?? []);
+    } catch (e: any) {
+      Alert.alert("エラー", "ボイス一覧の取得に失敗しました");
+    } finally {
+      setVoicesLoading(false);
+    }
+  };
+
+  const selectVoice = async (voiceId: string) => {
+    if (!deviceId) return;
+    setUpdatingVoice(true);
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(deviceId)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ voice_id: voiceId }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setRegisteredDevice((prev) => prev ? { ...prev, voice_id: voiceId } : prev);
+      setScreen("device-settings");
+    } catch (e: any) {
+      Alert.alert("エラー", "ボイスの更新に失敗しました");
+    } finally {
+      setUpdatingVoice(false);
+    }
+  };
+
+  const currentVoiceLabel = () => {
+    if (!registeredDevice?.voice_id) return "未設定";
+    const v = voices.find((v) => v.voice_id === registeredDevice.voice_id);
+    return v ? `${v.label} (${v.provider})` : registeredDevice.voice_id;
+  };
+
+  // ---- ボイス選択画面 ----
+  if (screen === "voice-select") {
+    const currentId = registeredDevice?.voice_id ?? DEFAULT_VOICE_ID;
+    return (
+      <SafeAreaView style={s.root}>
+        <View style={s.header}>
+          <TouchableOpacity onPress={() => setScreen("device-settings")}>
+            <Text style={s.back}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={s.headerTitle}>ボイス選択</Text>
+        </View>
+        {voicesLoading || updatingVoice ? (
+          <View style={s.center}>
+            <ActivityIndicator size="large" color="#007AFF" />
+          </View>
+        ) : (
+          <FlatList
+            data={voices}
+            keyExtractor={(item) => item.voice_id}
+            contentContainerStyle={{ padding: 16, gap: 8 }}
+            renderItem={({ item }) => {
+              const selected = item.voice_id === currentId;
+              return (
+                <TouchableOpacity
+                  style={[s.voiceItem, selected && s.voiceItemSelected]}
+                  onPress={() => selectVoice(item.voice_id)}
+                >
+                  <View style={s.voiceRow}>
+                    <View style={[s.radio, selected && s.radioSelected]} />
+                    <View>
+                      <Text style={[s.voiceLabel, selected && s.voiceLabelSelected]}>{item.label}</Text>
+                      <Text style={s.voiceProvider}>{item.provider}</Text>
+                    </View>
+                  </View>
+                </TouchableOpacity>
+              );
+            }}
+          />
+        )}
+      </SafeAreaView>
+    );
+  }
+
+  // ---- デバイス設定画面 ----
+  if (screen === "device-settings") {
+    return (
+      <SafeAreaView style={s.root}>
+        <View style={s.header}>
+          <TouchableOpacity onPress={() => setScreen("home")}>
+            <Text style={s.back}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={s.headerTitle}>デバイス設定</Text>
+        </View>
+        <View style={s.wrap}>
+          <Text style={s.deviceIdText}>{deviceId}</Text>
+          <TouchableOpacity style={s.settingRow} onPress={openVoiceSelect}>
+            <View>
+              <Text style={s.settingLabel}>ボイス</Text>
+              <Text style={s.settingValue}>{currentVoiceLabel()}</Text>
+            </View>
+            <Text style={s.chevron}>›</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // ---- ホーム画面 ----
   return (
     <SafeAreaView style={s.root}>
-      <View style={s.wrap}>
+      <ScrollView contentContainerStyle={s.wrap}>
         <Text style={s.title}>おもちゃ設定</Text>
 
-        {/* ステータス表示 */}
         {statusMessage ? (
           <View style={s.statusBox}>
             <Text style={s.statusText}>{statusMessage}</Text>
           </View>
         ) : null}
 
+        {/* 登録済みデバイス */}
+        {registeredDevice && (
+          <View style={s.section}>
+            <Text style={s.subtitle}>登録済みデバイス</Text>
+            <TouchableOpacity style={s.deviceItem} onPress={openDeviceSettings}>
+              <View>
+                <Text style={s.deviceName}>{registeredDevice.device_id}</Text>
+                <Text style={s.deviceSub}>
+                  ボイス: {registeredDevice.voice_id ?? "未設定"}
+                </Text>
+              </View>
+              <Text style={s.chevron}>›</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
         {/* 未接続時: スキャン */}
         {status === "disconnected" && (
           <>
             <TouchableOpacity style={s.button} onPress={startScan}>
-              <Text style={s.buttonText}>🔍 デバイスをスキャン</Text>
+              <Text style={s.buttonText}>デバイスをスキャン</Text>
             </TouchableOpacity>
 
-            {devices.length > 0 && (
-              <View style={s.deviceList}>
-                <Text style={s.subtitle}>見つかったデバイス:</Text>
-                <FlatList
-                  data={devices}
-                  keyExtractor={(item) => item.id}
-                  renderItem={({ item }) => (
-                    <TouchableOpacity
-                      style={s.deviceItem}
-                      onPress={() => connectToDevice(item)}
-                    >
+            {bleDevices.length > 0 && (
+              <View style={s.section}>
+                <Text style={s.subtitle}>見つかったデバイス</Text>
+                {bleDevices.map((item) => (
+                  <TouchableOpacity
+                    key={item.id}
+                    style={s.deviceItem}
+                    onPress={() => connectToDevice(item)}
+                  >
+                    <View>
                       <Text style={s.deviceName}>{item.name}</Text>
-                      <Text style={s.deviceId}>{item.id}</Text>
-                    </TouchableOpacity>
-                  )}
-                />
+                      <Text style={s.deviceSub}>{item.id}</Text>
+                    </View>
+                    <Text style={s.chevron}>›</Text>
+                  </TouchableOpacity>
+                ))}
               </View>
             )}
           </>
@@ -306,7 +441,7 @@ export default function Toy() {
               {status === "configuring" ? (
                 <ActivityIndicator color="#fff" />
               ) : (
-                <Text style={s.buttonText}>📶 WiFi設定を送信</Text>
+                <Text style={s.buttonText}>WiFi設定を送信</Text>
               )}
             </TouchableOpacity>
 
@@ -315,62 +450,49 @@ export default function Toy() {
             </TouchableOpacity>
           </View>
         )}
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: "#f5f5f5" },
-  wrap: { padding: 20, gap: 16 },
-  title: { fontSize: 24, fontWeight: "700", marginBottom: 8 },
-  subtitle: { fontSize: 18, fontWeight: "600", marginBottom: 8 },
-  statusBox: {
-    backgroundColor: "#e3f2fd",
-    padding: 12,
-    borderRadius: 8,
-  },
-  statusText: { fontSize: 14, color: "#1976d2" },
-  button: {
-    backgroundColor: "#007AFF",
-    padding: 16,
-    borderRadius: 12,
-    alignItems: "center",
-  },
-  buttonDisabled: {
-    backgroundColor: "#999",
-  },
-  buttonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
-  buttonSecondary: {
-    backgroundColor: "#fff",
-    padding: 14,
-    borderRadius: 12,
-    alignItems: "center",
-    borderWidth: 1,
-    borderColor: "#ddd",
-  },
-  buttonTextSecondary: { color: "#666", fontSize: 16 },
-  deviceList: { marginTop: 16 },
-  deviceItem: {
-    backgroundColor: "#fff",
-    padding: 16,
-    borderRadius: 8,
-    marginBottom: 8,
-    borderWidth: 1,
-    borderColor: "#e0e0e0",
-  },
-  deviceName: { fontSize: 16, fontWeight: "600" },
-  deviceId: { fontSize: 12, color: "#888", marginTop: 4 },
-  center: { alignItems: "center", gap: 16, marginTop: 20 },
-  loadingText: { fontSize: 16, color: "#666" },
-  form: { gap: 12 },
-  label: { fontSize: 14, fontWeight: "500", color: "#333" },
-  input: {
-    backgroundColor: "#fff",
-    padding: 14,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: "#ddd",
-    fontSize: 16,
-  },
+  root:               { flex: 1, backgroundColor: "#f5f5f5" },
+  wrap:               { padding: 20, gap: 16 },
+  title:              { fontSize: 24, fontWeight: "700", marginBottom: 8 },
+  subtitle:           { fontSize: 16, fontWeight: "600", marginBottom: 8, color: "#333" },
+  section:            { gap: 8 },
+  statusBox:          { backgroundColor: "#e3f2fd", padding: 12, borderRadius: 8 },
+  statusText:         { fontSize: 14, color: "#1976d2" },
+  button:             { backgroundColor: "#007AFF", padding: 16, borderRadius: 12, alignItems: "center" },
+  buttonDisabled:     { backgroundColor: "#999" },
+  buttonText:         { color: "#fff", fontSize: 16, fontWeight: "600" },
+  buttonSecondary:    { backgroundColor: "#fff", padding: 14, borderRadius: 12, alignItems: "center", borderWidth: 1, borderColor: "#ddd" },
+  buttonTextSecondary:{ color: "#666", fontSize: 16 },
+  deviceItem:         { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0", flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  deviceName:         { fontSize: 15, fontWeight: "600" },
+  deviceSub:          { fontSize: 12, color: "#888", marginTop: 2 },
+  center:             { alignItems: "center", gap: 16, marginTop: 20 },
+  loadingText:        { fontSize: 16, color: "#666" },
+  form:               { gap: 12 },
+  label:              { fontSize: 14, fontWeight: "500", color: "#333" },
+  input:              { backgroundColor: "#fff", padding: 14, borderRadius: 8, borderWidth: 1, borderColor: "#ddd", fontSize: 16 },
+  chevron:            { fontSize: 20, color: "#999" },
+  // ヘッダー
+  header:             { flexDirection: "row", alignItems: "center", padding: 16, gap: 12, backgroundColor: "#fff", borderBottomWidth: 1, borderBottomColor: "#e0e0e0" },
+  headerTitle:        { fontSize: 18, fontWeight: "600" },
+  back:               { fontSize: 16, color: "#007AFF" },
+  deviceIdText:       { fontSize: 12, color: "#999", marginBottom: 4 },
+  // デバイス設定画面
+  settingRow:         { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0", flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  settingLabel:       { fontSize: 15, fontWeight: "600" },
+  settingValue:       { fontSize: 13, color: "#666", marginTop: 2 },
+  // ボイス選択画面
+  voiceItem:          { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0" },
+  voiceItemSelected:  { borderColor: "#007AFF", backgroundColor: "#f0f7ff" },
+  voiceRow:           { flexDirection: "row", alignItems: "center", gap: 12 },
+  radio:              { width: 20, height: 20, borderRadius: 10, borderWidth: 2, borderColor: "#ccc" },
+  radioSelected:      { borderColor: "#007AFF", backgroundColor: "#007AFF" },
+  voiceLabel:         { fontSize: 15, fontWeight: "500" },
+  voiceLabelSelected: { color: "#007AFF", fontWeight: "600" },
+  voiceProvider:      { fontSize: 12, color: "#888", marginTop: 2 },
 });

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -30,7 +30,7 @@ const DEFAULT_VOICE_ID   = "elevenlabs_sameno";
 const bleManager = new BleManager();
 
 type ConnectionStatus = "disconnected" | "scanning" | "connecting" | "connected" | "configuring";
-type Screen = "home" | "device-settings" | "voice-select";
+type Screen = "home" | "wifi-setup" | "device-settings" | "voice-select";
 
 type VoiceItem = {
   voice_id: string;
@@ -137,6 +137,7 @@ export default function Toy() {
       setConnectedDevice(connected);
       setStatus("connected");
       setStatusMessage("接続完了！WiFi設定を入力してください");
+      setScreen("wifi-setup");
 
       connected.monitorCharacteristicForService(
         SERVICE_UUID,
@@ -229,6 +230,7 @@ export default function Toy() {
     setStatusMessage("");
     setSsid("");
     setPassword("");
+    setScreen("home");
     // registeredDevice と deviceId はAsyncStorageに保持（画面に残す）
   };
 
@@ -346,6 +348,69 @@ export default function Toy() {
     );
   }
 
+  // ---- WiFi設定画面 ----
+  if (screen === "wifi-setup") {
+    return (
+      <SafeAreaView style={s.root}>
+        <View style={s.header}>
+          <TouchableOpacity onPress={disconnect}>
+            <Text style={s.back}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={s.headerTitle}>WiFi設定</Text>
+        </View>
+        <ScrollView contentContainerStyle={s.wrap}>
+          {statusMessage ? (
+            <View style={s.statusBox}>
+              <Text style={s.statusText}>{statusMessage}</Text>
+            </View>
+          ) : null}
+
+          {status === "connecting" && (
+            <View style={s.center}>
+              <ActivityIndicator size="large" color="#007AFF" />
+              <Text style={s.loadingText}>接続中...</Text>
+            </View>
+          )}
+
+          {(status === "connected" || status === "configuring") && (
+            <View style={s.form}>
+              <Text style={s.label}>SSID (WiFi名)</Text>
+              <TextInput
+                style={s.input}
+                value={ssid}
+                onChangeText={setSsid}
+                placeholder="WiFiのSSIDを入力"
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+              <Text style={s.label}>パスワード</Text>
+              <TextInput
+                style={s.input}
+                value={password}
+                onChangeText={setPassword}
+                placeholder="WiFiのパスワードを入力"
+                secureTextEntry
+                autoCapitalize="none"
+                autoCorrect={false}
+              />
+              <TouchableOpacity
+                style={[s.button, status === "configuring" && s.buttonDisabled]}
+                onPress={sendWiFiConfig}
+                disabled={status === "configuring"}
+              >
+                {status === "configuring" ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <Text style={s.buttonText}>WiFi設定を送信</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
   // ---- ホーム画面 ----
   return (
     <SafeAreaView style={s.root}>
@@ -401,50 +466,6 @@ export default function Toy() {
           <View style={s.center}>
             <ActivityIndicator size="large" color="#007AFF" />
             <Text style={s.loadingText}>接続中...</Text>
-          </View>
-        )}
-
-        {/* 接続済み: WiFi設定フォーム */}
-        {(status === "connected" || status === "configuring") && (
-          <View style={s.form}>
-            <Text style={s.subtitle}>WiFi設定</Text>
-
-            <Text style={s.label}>SSID (WiFi名)</Text>
-            <TextInput
-              style={s.input}
-              value={ssid}
-              onChangeText={setSsid}
-              placeholder="WiFiのSSIDを入力"
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-
-            <Text style={s.label}>パスワード</Text>
-            <TextInput
-              style={s.input}
-              value={password}
-              onChangeText={setPassword}
-              placeholder="WiFiのパスワードを入力"
-              secureTextEntry
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-
-            <TouchableOpacity
-              style={[s.button, status === "configuring" && s.buttonDisabled]}
-              onPress={sendWiFiConfig}
-              disabled={status === "configuring"}
-            >
-              {status === "configuring" ? (
-                <ActivityIndicator color="#fff" />
-              ) : (
-                <Text style={s.buttonText}>WiFi設定を送信</Text>
-              )}
-            </TouchableOpacity>
-
-            <TouchableOpacity style={s.buttonSecondary} onPress={disconnect}>
-              <Text style={s.buttonTextSecondary}>切断</Text>
-            </TouchableOpacity>
           </View>
         )}
 

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -153,7 +153,8 @@ export default function Toy() {
       connected.onDisconnected(() => {
         setConnectedDevice(null);
         setStatus("disconnected");
-        setStatusMessage("切断されました");
+        setStatusMessage("");
+        setScreen("home");
       });
     } catch (error: any) {
       setStatus("disconnected");
@@ -216,6 +217,8 @@ export default function Toy() {
       await connectedDevice.writeCharacteristicWithResponseForService(SERVICE_UUID, CHAR_COMMAND_UUID, btoa("CONNECT"));
       setStatusMessage("設定送信完了、WiFi接続を待機中...");
     } catch (error: any) {
+      // BLE切断エラーはCONNECTコマンド処理後の正常切断の可能性があるので無視
+      if (error.message?.toLowerCase().includes("disconnect")) return;
       setStatus("connected");
       setStatusMessage("送信エラー: " + error.message);
     }

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   SafeAreaView,
   Text,
@@ -62,6 +63,14 @@ export default function Toy() {
     if (Platform.OS === "android") {
       requestAndroidPermissions();
     }
+    // AsyncStorageから登録済みデバイスを復元
+    AsyncStorage.getItem("registeredDevice").then((val) => {
+      if (val) {
+        const d = JSON.parse(val);
+        setRegisteredDevice(d);
+        setDeviceId(d.device_id);
+      }
+    });
     return () => {
       bleManager.stopDeviceScan();
     };
@@ -182,6 +191,7 @@ export default function Toy() {
       const deviceRes = await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(mac)}`);
       const deviceData = await deviceRes.json();
       setRegisteredDevice(deviceData);
+      await AsyncStorage.setItem("registeredDevice", JSON.stringify(deviceData));
       setStatusMessage("デバイス登録完了！");
     } catch (e: any) {
       setStatusMessage("デバイス登録エラー: " + e.message);
@@ -219,8 +229,7 @@ export default function Toy() {
     setStatusMessage("");
     setSsid("");
     setPassword("");
-    setRegisteredDevice(null);
-    setDeviceId(null);
+    // registeredDevice と deviceId はAsyncStorageに保持（画面に残す）
   };
 
   const openDeviceSettings = () => {
@@ -251,7 +260,11 @@ export default function Toy() {
         body: JSON.stringify({ voice_id: voiceId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setRegisteredDevice((prev) => prev ? { ...prev, voice_id: voiceId } : prev);
+      setRegisteredDevice((prev) => {
+        const updated = prev ? { ...prev, voice_id: voiceId } : prev;
+        if (updated) AsyncStorage.setItem("registeredDevice", JSON.stringify(updated));
+        return updated;
+      });
       setScreen("device-settings");
     } catch (e: any) {
       Alert.alert("エラー", "ボイスの更新に失敗しました");
@@ -345,22 +358,6 @@ export default function Toy() {
           </View>
         ) : null}
 
-        {/* 登録済みデバイス */}
-        {registeredDevice && (
-          <View style={s.section}>
-            <Text style={s.subtitle}>登録済みデバイス</Text>
-            <TouchableOpacity style={s.deviceItem} onPress={openDeviceSettings}>
-              <View>
-                <Text style={s.deviceName}>{registeredDevice.device_id}</Text>
-                <Text style={s.deviceSub}>
-                  ボイス: {registeredDevice.voice_id ?? "未設定"}
-                </Text>
-              </View>
-              <Text style={s.chevron}>›</Text>
-            </TouchableOpacity>
-          </View>
-        )}
-
         {/* 未接続時: スキャン */}
         {status === "disconnected" && (
           <>
@@ -447,6 +444,22 @@ export default function Toy() {
 
             <TouchableOpacity style={s.buttonSecondary} onPress={disconnect}>
               <Text style={s.buttonTextSecondary}>切断</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
+        {/* 登録済みデバイス（常に最下部に表示） */}
+        {registeredDevice && (
+          <View style={s.section}>
+            <Text style={s.subtitle}>登録済みデバイス</Text>
+            <TouchableOpacity style={s.deviceItem} onPress={openDeviceSettings}>
+              <View>
+                <Text style={s.deviceName}>{registeredDevice.device_id}</Text>
+                <Text style={s.deviceSub}>
+                  ボイス: {registeredDevice.voice_id ?? "未設定"}
+                </Text>
+              </View>
+              <Text style={s.chevron}>›</Text>
             </TouchableOpacity>
           </View>
         )}

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -7,7 +7,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   TextInput,
-  FlatList,
+  SectionList,
   Alert,
   ActivityIndicator,
   Platform,
@@ -24,8 +24,9 @@ const CHAR_COMMAND_UUID  = "12345678-1234-1234-1234-123456789ab3";
 const CHAR_STATUS_UUID   = "12345678-1234-1234-1234-123456789ab4";
 const CHAR_MAC_UUID      = "12345678-1234-1234-1234-123456789ab5";
 
-const DEVICE_SETTING_URL = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
-const DEFAULT_VOICE_ID   = "elevenlabs_sameno";
+const DEVICE_SETTING_URL  = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
+const DEFAULT_VOICE_ID    = "elevenlabs_sameno";
+const PROVIDER_ORDER      = ["OpenAI", "Google", "Gemini", "ElevenLabs", "FishAudio"];
 
 const bleManager = new BleManager();
 
@@ -287,6 +288,13 @@ export default function Toy() {
   // ---- ボイス選択画面 ----
   if (screen === "voice-select") {
     const currentId = registeredDevice?.voice_id ?? DEFAULT_VOICE_ID;
+    const sections = PROVIDER_ORDER
+      .map((provider) => ({
+        title: provider,
+        data: voices.filter((v) => v.provider === provider),
+      }))
+      .filter((s) => s.data.length > 0);
+
     return (
       <SafeAreaView style={s.root}>
         <View style={s.header}>
@@ -300,10 +308,13 @@ export default function Toy() {
             <ActivityIndicator size="large" color="#007AFF" />
           </View>
         ) : (
-          <FlatList
-            data={voices}
+          <SectionList
+            sections={sections}
             keyExtractor={(item) => item.voice_id}
             contentContainerStyle={{ padding: 16, gap: 8 }}
+            renderSectionHeader={({ section }) => (
+              <Text style={s.sectionHeader}>{section.title}</Text>
+            )}
             renderItem={({ item }) => {
               const selected = item.voice_id === currentId;
               return (
@@ -313,10 +324,7 @@ export default function Toy() {
                 >
                   <View style={s.voiceRow}>
                     <View style={[s.radio, selected && s.radioSelected]} />
-                    <View>
-                      <Text style={[s.voiceLabel, selected && s.voiceLabelSelected]}>{item.label}</Text>
-                      <Text style={s.voiceProvider}>{item.provider}</Text>
-                    </View>
+                    <Text style={[s.voiceLabel, selected && s.voiceLabelSelected]}>{item.label}</Text>
                   </View>
                 </TouchableOpacity>
               );
@@ -532,4 +540,5 @@ const s = StyleSheet.create({
   voiceLabel:         { fontSize: 15, fontWeight: "500" },
   voiceLabelSelected: { color: "#007AFF", fontWeight: "600" },
   voiceProvider:      { fontSize: 12, color: "#888", marginTop: 2 },
+  sectionHeader:      { fontSize: 13, fontWeight: "700", color: "#555", marginTop: 12, marginBottom: 6, textTransform: "uppercase" },
 });

--- a/app/constants/ModelMap.ts
+++ b/app/constants/ModelMap.ts
@@ -1,0 +1,65 @@
+export const MODEL_MAP = {
+  OpenAI: {
+    label: "OpenAI",
+    desc: "4o-mini-tts",
+    defaultVoice: "nova",
+    voices: {
+      alloy: { label: "Alloy – neutral male", vendorId: "alloy" },
+      nova: { label: "Nova – kind female", vendorId: "nova" },
+      verse: { label: "Verse – calm narrator", vendorId: "verse" },
+    },
+  },
+  Google: {
+    label: "Google",
+    desc: "Google TTS",
+    defaultVoice: "jaB",
+    voices: {
+      jaB: { label: "JP-B – soft female", vendorId: "ja-JP-Neural2-B" },
+      jaC: { label: "JP-C – soft male", vendorId: "ja-JP-Neural2-C" },
+    },
+  },
+  Gemini: {
+    label: "Gemini",
+    desc: "2.5 Flash TTS",
+    defaultVoice: "leda",
+    voices: {
+      leda: { label: "Leda – clear female", vendorId: "leda" },
+      puck: { label: "Puck – clear male", vendorId: "puck" },
+    },
+  },
+  ElevenLabs: {
+    label: "ElevenLabs",
+    desc: "Turbo v2.5",
+    defaultVoice: "sameno",
+    voices: {
+      sameno: { label: "Sameno", vendorId: "hMK7c1GPJmptCzI4bQIu" },
+    },
+  },
+  FishAudio: {
+    label: "Fish Audio (demo)",
+    desc: "Fish Audio TTS",
+    defaultVoice: "sansan",
+    voices: {
+      sansan: { label: "サンサン", vendorId: "15454ccda92d4246a821a5d8f9728fb9" },
+      pikachu: { label: "ピカチュウ", vendorId: "d940622bd99742c6b10ececd13c7ee1c" },
+      doraemon: { label: "ドラえもん", vendorId: "7ad5d736bec7410090caf00dd91db21f" },
+      conan: { label: "コナン", vendorId: "8481836597324f1697052575e2ca1a7e" },
+      tanjiro: { label: "竈門炭治郎", vendorId: "00948a6e032249199e4a2699f0e0828e" },
+      rengoku: { label: "煉獄杏寿郎", vendorId: "738068acdf0346d4ad15873cf582b9c9" },
+      muzan: { label: "鬼舞辻無惨", vendorId: "18833cce92cc42e682f68073177f0e8f" },
+      frieren: { label: "フリーレン", vendorId: "5a7a3dec0d9c415db57e9a7ce2ecee51" },
+      fern: { label: "フェルン", vendorId: "1dac8f5fd50648388edfcb4ca6cfb378" },
+      misato: { label: "葛城ミサト", vendorId: "5ec124a55410453a9c56aae75d3ba4c0" },
+      makima: { label: "マキマ", vendorId: "028c4c7eb08c43358a3e30fef264ca0e" },
+      reze: { label: "レゼ", vendorId: "6fdaebea7db042129f03ecb0a57ea7b6" },
+      light: { label: "夜神月", vendorId: "4bc1d3d1fa60415f989b8e0b99f333e1" },
+      naoya: { label: "禪院直哉", vendorId: "028e1ae4ba6d4c039ce29726a694500e" },
+      marine: { label: "マリン船長", vendorId: "b24f3e45d0fc49ee942eb00741d70316" },
+      hiroyuki: { label: "ひろゆき", vendorId: "f59b9bff8c37434aafed363ca72d14dc" },
+      miwa: { label: "美輪明宏", vendorId: "d0407bac2cd14321bdfb492fa16506d7" },
+      matsuko: { label: "マツコ・デラックス", vendorId: "e533e9f4f01d49dd8fb3e39dd3914464" },
+    },
+  },
+} as const;
+
+export type ModelKey = keyof typeof MODEL_MAP;

--- a/backend/toytalk-api-stream-for-esp32-lambda/deploy.sh
+++ b/backend/toytalk-api-stream-for-esp32-lambda/deploy.sh
@@ -4,7 +4,10 @@
 cd "$(dirname "$0")"
 
 echo "📦 Bundling with esbuild..."
-"/c/Program Files/nodejs/npx.cmd" esbuild index.mjs --bundle --platform=node --format=esm --outfile=bundle.mjs
+"/c/Program Files/nodejs/npx.cmd" esbuild index.mjs --bundle --platform=node --format=esm \
+  --external:@aws-sdk/client-dynamodb \
+  --external:@aws-sdk/lib-dynamodb \
+  --outfile=bundle.mjs
 
 echo "📁 Creating zip..."
 mkdir -p temp_deploy

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -1,8 +1,15 @@
   // Node.js 18+ / ESM（index.mjs）
   // Handler: index.handler
-  // Env: OPENAI_API_KEY
+  // Env: OPENAI_API_KEY, GOOGLE_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY
   import OpenAI from "openai";
   import { createHash } from "node:crypto";
+  import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+  import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+
+  const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
+  const ddb = DynamoDBDocumentClient.from(ddbClient);
+  const DEVICES_TABLE = "toytalker-devices";
+  const VOICES_TABLE  = "toytalker-voices";
 
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -41,33 +48,35 @@
   const MODEL_DEFAULT = "OpenAI";
   /** 将来の拡張用にテーブル化しておく（今は OpenAI だけ使う） */
   const MODEL_TABLE = {
-    // LLM: OpenAI / TTS: OpenAI
     OpenAI: {
       llmVendor: "openai",
       llmModel:  "gpt-4.1-mini",
       ttsVendor: "openai",
       ttsModel:  "gpt-4o-mini-tts-2025-03-20",
     },
-    // LLM: OpenAI / TTS: Google Cloud Text-to-Speech
     Google: {
       llmVendor: "openai",
       llmModel:  "gpt-4.1-mini",
       ttsVendor: "google",
       ttsModel:  "google-tts",
     },
-    // LLM: OpenAI / TTS: Gemini Speech Generation
     Gemini: {
       llmVendor: "openai",
       llmModel:  "gpt-4.1-mini",
       ttsVendor: "gemini",
-      ttsModel:  "gemini-2.5-flash-preview-tts",   // 名称は任意（識別用）
+      ttsModel:  "gemini-2.5-flash-preview-tts",
     },
-    // LLM: OpenAI / TTS: ElevenLabs
     ElevenLabs: {
       llmVendor: "openai",
       llmModel:  "gpt-4.1-mini",
       ttsVendor: "elevenlabs",
       ttsModel:  "eleven_turbo_v2_5",
+    },
+    FishAudio: {
+      llmVendor: "openai",
+      llmModel:  "gpt-4.1-mini",
+      ttsVendor: "fishaudio",
+      ttsModel:  "fishaudio",
     },
   };
 
@@ -260,15 +269,54 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
   }
 
 
+  // FishAudio TTS → Buffer (raw PCM via MP3 decode is not feasible on Lambda;
+  // FishAudio supports pcm output via format param)
+  async function ttsBufferFishAudio(text, { referenceId = "hMK7c1GPJmptCzI4bQIu" } = {}) {
+    const key = process.env.FISHAUDIO_API_KEY;
+    if (!key) throw new Error("FISHAUDIO_API_KEY is not set");
+    const resp = await fetch("https://api.fish.audio/v1/tts", {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ text, reference_id: referenceId, format: "pcm", sample_rate: 24000, latency: "normal" }),
+    });
+    if (!resp.ok) {
+      const errorText = await resp.text();
+      throw new Error(`FishAudio TTS failed: ${resp.status} ${errorText}`);
+    }
+    const pcmBuffer = Buffer.from(await resp.arrayBuffer());
+    console.log(`[TTS FishAudio] PCM size: ${pcmBuffer.length} bytes`);
+    return pcmBuffer;
+  }
+
+  // DynamoDBからdevice_idに紐づくvoice設定を解決
+  async function resolveVoiceFromDynamo(deviceId) {
+    try {
+      const deviceRes = await ddb.send(new GetCommand({
+        TableName: DEVICES_TABLE,
+        Key: { device_id: deviceId },
+      }));
+      const voiceId = deviceRes.Item?.voice_id;
+      if (!voiceId) return null;
+
+      const voiceRes = await ddb.send(new GetCommand({
+        TableName: VOICES_TABLE,
+        Key: { voice_id: voiceId },
+      }));
+      if (!voiceRes.Item) return null;
+
+      return { provider: voiceRes.Item.provider, vendorId: voiceRes.Item.vendor_id };
+    } catch (e) {
+      console.error("[DynamoDB] resolveVoiceFromDynamo error:", e);
+      return null;
+    }
+  }
+
   export const handler = awslambda.streamifyResponse(async (event, res) => {
     res.setContentType("application/octet-stream");
 
     const body    = event.body ? JSON.parse(event.body) : {};
-    const voice   = body.voice ?? VOICE_DEFAULT;
     const messages= body.messages ?? [{ role:"user", content:"自己紹介して" }];
-    const rawModel = typeof body.model === "string" ? body.model : undefined;
-    const modelKey = normalizeModelKey(rawModel) ?? MODEL_DEFAULT;
-    const cfg      = MODEL_TABLE[modelKey] ?? MODEL_TABLE[MODEL_DEFAULT];
+    const deviceId = typeof body.device_id === "string" ? body.device_id : null;
 
     function normalizeModelKey(k) {
       if (!k) return undefined;
@@ -277,8 +325,26 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       if (s.includes("google"))      return "Google";
       if (s.includes("gemini"))      return "Gemini";
       if (s.includes("elevenlabs"))  return "ElevenLabs";
-      return undefined; // 不明ならデフォルトにフォールバック
+      if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
+      return undefined;
     }
+
+    // device_idがあればDynamoDBからボイス設定を取得、なければbodyの値を使う
+    let modelKey = normalizeModelKey(body.model) ?? MODEL_DEFAULT;
+    let voice    = body.voice ?? VOICE_DEFAULT;
+
+    if (deviceId) {
+      const voiceConfig = await resolveVoiceFromDynamo(deviceId);
+      if (voiceConfig) {
+        modelKey = normalizeModelKey(voiceConfig.provider) ?? modelKey;
+        voice    = voiceConfig.vendorId ?? voice;
+        console.log(`[DynamoDB] device=${deviceId}, provider=${voiceConfig.provider}, vendorId=${voiceConfig.vendorId}`);
+      } else {
+        console.log(`[DynamoDB] device=${deviceId} not found or no voice set, using defaults`);
+      }
+    }
+
+    const cfg = MODEL_TABLE[modelKey] ?? MODEL_TABLE[MODEL_DEFAULT];
 
 
     // クライアント側の計測・デバッグ用に「採用モデル」を通知
@@ -365,6 +431,9 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         } else if (cfg.ttsVendor === "elevenlabs") {
           const voiceId = voice === "default" ? "hMK7c1GPJmptCzI4bQIu" : voice;  // Sameno（子供向け）
           pcmBuffer = await ttsBufferElevenLabs(t, { model: cfg.ttsModel, voiceId });
+        } else if (cfg.ttsVendor === "fishaudio") {
+          const referenceId = voice === "default" ? "hMK7c1GPJmptCzI4bQIu" : voice;
+          pcmBuffer = await ttsBufferFishAudio(t, { referenceId });
         } else {
           throw new Error("Unknown ttsVendor");
         }

--- a/backend/toytalk-api-stream-for-esp32-lambda/package-lock.json
+++ b/backend/toytalk-api-stream-for-esp32-lambda/package-lock.json
@@ -9,8 +9,1345 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/lib-dynamodb": "^3.0.0",
         "openai": "^6.3.0"
       }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1004.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1004.0.tgz",
+      "integrity": "sha512-NYQPxtfc0hWNUlbZMkgjAyudPzgK6WA5BRh9+/zCQYrBvgtk347g64gnxqyyF+W3QWNhFEp7Eo3heHiNN++9Wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.18",
+        "@aws-sdk/dynamodb-codec": "^3.972.19",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.7",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.4",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
+      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/xml-builder": "^3.972.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
+      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
+      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.17.tgz",
+      "integrity": "sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-login": "^3.972.17",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.17",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.17.tgz",
+      "integrity": "sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.18.tgz",
+      "integrity": "sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-ini": "^3.972.17",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.17",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
+      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.17.tgz",
+      "integrity": "sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/token-providers": "3.1004.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.17.tgz",
+      "integrity": "sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.19.tgz",
+      "integrity": "sha512-M/y+eA53imfFxA/QjrpfnyhG/eLIHxsNI6GmevwIVoX7E1vGYyevKt1iJ+aZwOVbL9lLeHtlBuYUEhYgVjwDpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@smithy/core": "^3.23.8",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.4.tgz",
+      "integrity": "sha512-GdASDnWanLnHxKK0hqV97xz23QmfA/C8yGe0PiuEmWiHSe+x+x+mFEj4sXqx9IbfyPncWz8f4EhNwBSG9cgYCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1004.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1004.0.tgz",
+      "integrity": "sha512-vjs33MmH7et6T/dMhkykgKGDLRUVuV8sd9X6qtXKWN5HMRgtQYNvabHVXTpm4OVPG28+wUOWKAHNwvwsc23LaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/util-dynamodb": "^3.996.2",
+        "@smithy/core": "^3.23.8",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1004.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.7.tgz",
+      "integrity": "sha512-ZeFfgAVOGR+fDq/JAPsVA3P07ba74hIppoGfmQyfzZMfAQAzc9Lbg5pndZU8EanzfKnlXbv6y09OMrSkTsUuOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.4",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
+      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
+      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
+      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.19.tgz",
+      "integrity": "sha512-Km90fcXt3W/iqujHzuM6IaDkYCj73gsYufcuWXApWdzoTy6KGk8fnchAjePMARU0xegIR3K4N3yIo1vy7OVe8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@smithy/core": "^3.23.8",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-retry": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.7.tgz",
+      "integrity": "sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.4",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
+      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1004.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1004.0.tgz",
+      "integrity": "sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
+      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.2.tgz",
+      "integrity": "sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1003.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
+      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
+      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.4.tgz",
+      "integrity": "sha512-uqKeLqZ9D3nQjH7HGIERNXK9qnSpUK08l4MlJ5/NZqSSdeJsVANYp437EM9sEzwU28c2xfj2V6qlkqzsgtKs6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
+      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.9",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz",
+      "integrity": "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
+      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
+      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
+      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
+      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
+      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.23",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz",
+      "integrity": "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.9",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.40",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz",
+      "integrity": "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
+      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
+      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
+      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
+      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
+      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
+      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
+      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
+      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz",
+      "integrity": "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.9",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
+      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.39",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz",
+      "integrity": "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.42",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz",
+      "integrity": "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
+      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
+      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
+      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.11.tgz",
+      "integrity": "sha512-x7Rh2azQPs3XxbvCzcttRErKKvLnbZfqRf/gOjw2pb+ZscX88e5UkRPCB67bVnsFHxayvMvmePfKTqsRb+is1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/openai": {
       "version": "6.3.0",
@@ -32,6 +1369,24 @@
           "optional": true
         }
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     }
   }
 }

--- a/backend/toytalk-api-stream-for-esp32-lambda/package.json
+++ b/backend/toytalk-api-stream-for-esp32-lambda/package.json
@@ -10,6 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "openai": "^6.3.0"
+    "openai": "^6.3.0",
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0"
   }
 }

--- a/backend/toytalker-device-setting-lambda/deploy.sh
+++ b/backend/toytalker-device-setting-lambda/deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+
+echo "📦 Installing dependencies..."
+"/c/Program Files/nodejs/npm.cmd" install
+
+echo "📦 Bundling with esbuild..."
+"/c/Program Files/nodejs/npx.cmd" esbuild index.mjs --bundle --platform=node --format=cjs --outfile=bundle.js
+
+echo "📁 Creating zip..."
+mkdir -p temp_deploy
+cp bundle.js temp_deploy/index.js
+cd temp_deploy
+powershell -Command "Compress-Archive -Path 'index.js' -DestinationPath '../deploy.zip' -Force"
+cd ..
+rm -rf temp_deploy
+
+echo "🚀 Deploying to Lambda..."
+aws lambda update-function-code \
+  --function-name toytalker-device-setting-lambda \
+  --zip-file fileb://deploy.zip \
+  --region ap-northeast-1 \
+  --query '[CodeSize, LastModified]' \
+  --output text
+
+echo "✅ Done!"

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -1,0 +1,106 @@
+// Node.js 18+ / ESM（index.mjs）
+// Handler: index.handler
+// Env: なし（DynamoDBはIAMロールで接続）
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+
+const client = new DynamoDBClient({ region: "ap-northeast-1" });
+const ddb = DynamoDBDocumentClient.from(client);
+
+// ---- テーブル定義 ----
+const DEVICES_TABLE = "toytalker-devices";
+const VOICES_TABLE  = "toytalker-voices";
+
+const response = (statusCode, body) => ({
+  statusCode,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+export const handler = async (event) => {
+  const method = event.requestContext?.http?.method ?? "GET";
+  const path   = event.rawPath ?? "/";
+
+  console.log(`[Request] ${method} ${path}`);
+
+  try {
+
+    // ---- GET /voices ---- ボイス一覧取得
+    if (method === "GET" && path === "/voices") {
+      const result = await ddb.send(new ScanCommand({ TableName: VOICES_TABLE }));
+      return response(200, { voices: result.Items ?? [] });
+    }
+
+    // ---- POST /devices ---- デバイス登録
+    if (method === "POST" && path === "/devices") {
+      const body      = JSON.parse(event.body ?? "{}");
+      const { device_id, owner_id = "user_123" } = body;
+      if (!device_id) return response(400, { error: "device_id is required" });
+
+      const now = new Date().toISOString();
+      await ddb.send(new PutCommand({
+        TableName: DEVICES_TABLE,
+        Item: {
+          device_id,
+          owner_id,
+          character_id: "default",
+          voice_id: null,
+          created_at: now,
+          last_seen: now,
+        },
+        // すでに存在する場合は created_at を上書きしない
+        ConditionExpression: "attribute_not_exists(device_id)",
+      })).catch(async (err) => {
+        if (err.name === "ConditionalCheckFailedException") {
+          // 登録済みなら last_seen だけ更新
+          await ddb.send(new UpdateCommand({
+            TableName: DEVICES_TABLE,
+            Key: { device_id },
+            UpdateExpression: "SET last_seen = :t",
+            ExpressionAttributeValues: { ":t": now },
+          }));
+        } else {
+          throw err;
+        }
+      });
+
+      return response(200, { device_id, message: "Device registered" });
+    }
+
+    // ---- GET /devices/{device_id} ---- デバイス取得
+    if (method === "GET" && path.startsWith("/devices/")) {
+      const device_id = decodeURIComponent(path.split("/")[2]);
+      const result = await ddb.send(new GetCommand({
+        TableName: DEVICES_TABLE,
+        Key: { device_id },
+      }));
+      if (!result.Item) return response(404, { error: "Device not found" });
+      return response(200, result.Item);
+    }
+
+    // ---- PUT /devices/{device_id} ---- ボイス設定更新
+    if (method === "PUT" && path.startsWith("/devices/")) {
+      const device_id = decodeURIComponent(path.split("/")[2]);
+      const body      = JSON.parse(event.body ?? "{}");
+      const { voice_id } = body;
+      if (!voice_id) return response(400, { error: "voice_id is required" });
+
+      await ddb.send(new UpdateCommand({
+        TableName: DEVICES_TABLE,
+        Key: { device_id },
+        UpdateExpression: "SET voice_id = :v, last_seen = :t",
+        ExpressionAttributeValues: {
+          ":v": voice_id,
+          ":t": new Date().toISOString(),
+        },
+      }));
+      return response(200, { device_id, voice_id, message: "Device updated" });
+    }
+
+    return response(404, { error: "Not found" });
+
+  } catch (err) {
+    console.error("[Error]", err);
+    return response(500, { error: err?.message ?? "Internal server error" });
+  }
+};

--- a/backend/toytalker-device-setting-lambda/package-lock.json
+++ b/backend/toytalker-device-setting-lambda/package-lock.json
@@ -1,0 +1,1369 @@
+{
+  "name": "toytalker-device-setting-lambda",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "toytalker-device-setting-lambda",
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0",
+        "@aws-sdk/lib-dynamodb": "^3.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1004.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1004.0.tgz",
+      "integrity": "sha512-NYQPxtfc0hWNUlbZMkgjAyudPzgK6WA5BRh9+/zCQYrBvgtk347g64gnxqyyF+W3QWNhFEp7Eo3heHiNN++9Wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-node": "^3.972.18",
+        "@aws-sdk/dynamodb-codec": "^3.972.19",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.7",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.4",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.18.tgz",
+      "integrity": "sha512-GUIlegfcK2LO1J2Y98sCJy63rQSiLiDOgVw7HiHPRqfI2vb3XozTVqemwO0VSGXp54ngCnAQz0Lf0YPCBINNxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/xml-builder": "^3.972.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/signature-v4": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.16.tgz",
+      "integrity": "sha512-HrdtnadvTGAQUr18sPzGlE5El3ICphnH6SU7UQOMOWFgRKbTRNN8msTxM4emzguUso9CzaHU2xy5ctSrmK5YNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz",
+      "integrity": "sha512-NyB6smuZAixND5jZumkpkunQ0voc4Mwgkd+SZ6cvAzIB7gK8HV8Zd4rS8Kn5MmoGgusyNfVGG+RLoYc4yFiw+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.17.tgz",
+      "integrity": "sha512-dFqh7nfX43B8dO1aPQHOcjC0SnCJ83H3F+1LoCh3X1P7E7N09I+0/taID0asU6GCddfDExqnEvQtDdkuMe5tKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-login": "^3.972.17",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.17",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.17.tgz",
+      "integrity": "sha512-gf2E5b7LpKb+JX2oQsRIDxdRZjBFZt2olCGlWCdb3vBERbXIPgm2t1R5mEnwd4j0UEO/Tbg5zN2KJbHXttJqwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.18.tgz",
+      "integrity": "sha512-ZDJa2gd1xiPg/nBDGhUlat02O8obaDEnICBAVS8qieZ0+nDfaB0Z3ec6gjZj27OqFTjnB/Q5a0GwQwb7rMVViw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.16",
+        "@aws-sdk/credential-provider-http": "^3.972.18",
+        "@aws-sdk/credential-provider-ini": "^3.972.17",
+        "@aws-sdk/credential-provider-process": "^3.972.16",
+        "@aws-sdk/credential-provider-sso": "^3.972.17",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.17",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz",
+      "integrity": "sha512-n89ibATwnLEg0ZdZmUds5bq8AfBAdoYEDpqP3uzPLaRuGelsKlIvCYSNNvfgGLi8NaHPNNhs1HjJZYbqkW9b+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.17.tgz",
+      "integrity": "sha512-wGtte+48xnhnhHMl/MsxzacBPs5A+7JJedjiP452IkHY7vsbYKcvQBqFye8LwdTJVeHtBHv+JFeTscnwepoWGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/token-providers": "3.1004.0",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.17.tgz",
+      "integrity": "sha512-8aiVJh6fTdl8gcyL+sVNcNwTtWpmoFa1Sh7xlj6Z7L/cZ/tYMEBHq44wTYG8Kt0z/PpGNopD89nbj3FHl9QmTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.972.19.tgz",
+      "integrity": "sha512-M/y+eA53imfFxA/QjrpfnyhG/eLIHxsNI6GmevwIVoX7E1vGYyevKt1iJ+aZwOVbL9lLeHtlBuYUEhYgVjwDpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@smithy/core": "^3.23.8",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.4.tgz",
+      "integrity": "sha512-GdASDnWanLnHxKK0hqV97xz23QmfA/C8yGe0PiuEmWiHSe+x+x+mFEj4sXqx9IbfyPncWz8f4EhNwBSG9cgYCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1004.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1004.0.tgz",
+      "integrity": "sha512-vjs33MmH7et6T/dMhkykgKGDLRUVuV8sd9X6qtXKWN5HMRgtQYNvabHVXTpm4OVPG28+wUOWKAHNwvwsc23LaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/util-dynamodb": "^3.996.2",
+        "@smithy/core": "^3.23.8",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1004.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.7.tgz",
+      "integrity": "sha512-ZeFfgAVOGR+fDq/JAPsVA3P07ba74hIppoGfmQyfzZMfAQAzc9Lbg5pndZU8EanzfKnlXbv6y09OMrSkTsUuOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.4",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.7.tgz",
+      "integrity": "sha512-aHQZgztBFEpDU1BB00VWCIIm85JjGjQW1OG9+98BdmaOpguJvzmXBGbnAiYcciCd+IS4e9BEq664lhzGnWJHgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.7.tgz",
+      "integrity": "sha512-LXhiWlWb26txCU1vcI9PneESSeRp/RYY/McuM4SpdrimQR5NgwaPb4VJCadVeuGWgh6QmqZ6rAKSoL1ob16W6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.7.tgz",
+      "integrity": "sha512-l2VQdcBcYLzIzykCHtXlbpiVCZ94/xniLIkAj0jpnpjY4xlgZx7f56Ypn+uV1y3gG0tNVytJqo3K9bfMFee7SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.19.tgz",
+      "integrity": "sha512-Km90fcXt3W/iqujHzuM6IaDkYCj73gsYufcuWXApWdzoTy6KGk8fnchAjePMARU0xegIR3K4N3yIo1vy7OVe8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@smithy/core": "^3.23.8",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-retry": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.7.tgz",
+      "integrity": "sha512-MlGWA8uPaOs5AiTZ5JLM4uuWDm9EEAnm9cqwvqQIc6kEgel/8s1BaOWm9QgUcfc9K8qd7KkC3n43yDbeXOA2tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/middleware-host-header": "^3.972.7",
+        "@aws-sdk/middleware-logger": "^3.972.7",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
+        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/region-config-resolver": "^3.972.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/util-endpoints": "^3.996.4",
+        "@aws-sdk/util-user-agent-browser": "^3.972.7",
+        "@aws-sdk/util-user-agent-node": "^3.973.4",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/core": "^3.23.8",
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/hash-node": "^4.2.11",
+        "@smithy/invalid-dependency": "^4.2.11",
+        "@smithy/middleware-content-length": "^4.2.11",
+        "@smithy/middleware-endpoint": "^4.4.22",
+        "@smithy/middleware-retry": "^4.4.39",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/smithy-client": "^4.12.2",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.38",
+        "@smithy/util-defaults-mode-node": "^4.2.41",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.7.tgz",
+      "integrity": "sha512-/Ev/6AI8bvt4HAAptzSjThGUMjcWaX3GX8oERkB0F0F9x2dLSBdgFDiyrRz3i0u0ZFZFQ1b28is4QhyqXTUsVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1004.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1004.0.tgz",
+      "integrity": "sha512-j9BwZZId9sFp+4GPhf6KrwO8Tben2sXibZA8D1vv2I1zBdvkUHcBA2g4pkqIpTRalMTLC0NPkBPX0gERxfy/iA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.18",
+        "@aws-sdk/nested-clients": "^3.996.7",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.5.tgz",
+      "integrity": "sha512-hl7BGwDCWsjH8NkZfx+HgS7H2LyM2lTMAI7ba9c8O0KqdBLTdNJivsHpqjg9rNlAlPyREb6DeDRXUl0s8uFdmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.2.tgz",
+      "integrity": "sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1003.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.4.tgz",
+      "integrity": "sha512-Hek90FBmd4joCFj+Vc98KLJh73Zqj3s2W56gjAcTkrNLMDI5nIFkG9YpfcJiVI1YlE2Ne1uOQNe+IgQ/Vz2XRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-endpoints": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.7.tgz",
+      "integrity": "sha512-7SJVuvhKhMF/BkNS1n0QAJYgvEwYbK2QLKBrzDiwQGiTRU6Yf1f3nehTzm/l21xdAOtWSfp2uWSddPnP2ZtsVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/types": "^4.13.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.4.tgz",
+      "integrity": "sha512-uqKeLqZ9D3nQjH7HGIERNXK9qnSpUK08l4MlJ5/NZqSSdeJsVANYp437EM9sEzwU28c2xfj2V6qlkqzsgtKs6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.19",
+        "@aws-sdk/types": "^3.973.5",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
+      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "fast-xml-parser": "5.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
+      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.10",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
+      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.9",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.9.tgz",
+      "integrity": "sha512-1Vcut4LEL9HZsdpI0vFiRYIsaoPwZLjAxnVQDUMQK8beMS+EYPLDQCXtbzfxmM5GzSgjfe2Q9M7WaXwIMQllyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
+      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
+      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.11.tgz",
+      "integrity": "sha512-T+p1pNynRkydpdL015ruIoyPSRw9e/SQOWmSAMmmprfswMrd5Ow5igOWNVlvyVFZlxXqGmyH3NQwfwy8r5Jx0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.11.tgz",
+      "integrity": "sha512-cGNMrgykRmddrNhYy1yBdrp5GwIgEkniS7k9O1VLB38yxQtlvrxpZtUVvo6T4cKpeZsriukBuuxfJcdZQc/f/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.11.tgz",
+      "integrity": "sha512-UvIfKYAKhCzr4p6jFevPlKhQwyQwlJ6IeKLDhmV1PlYfcW3RL4ROjNEDtSik4NYMi9kDkH7eSwyTP3vNJ/u/Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.23",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.23.tgz",
+      "integrity": "sha512-UEFIejZy54T1EJn2aWJ45voB7RP2T+IRzUqocIdM6GFFa5ClZncakYJfcYnoXt3UsQrZZ9ZRauGm77l9UCbBLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.9",
+        "@smithy/middleware-serde": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "@smithy/url-parser": "^4.2.11",
+        "@smithy/util-middleware": "^4.2.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.40",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.40.tgz",
+      "integrity": "sha512-YhEMakG1Ae57FajERdHNZ4ShOPIY7DsgV+ZoAxo/5BT0KIe+f6DDU2rtIymNNFIj22NJfeeI6LWIifrwM0f+rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-retry": "^4.2.11",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
+      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
+      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
+      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/shared-ini-file-loader": "^4.4.6",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
+      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/querystring-builder": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
+      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
+      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
+      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
+      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
+      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
+      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.11.tgz",
+      "integrity": "sha512-V1L6N9aKOBAN4wEHLyqjLBnAz13mtILU0SeDrjOaIZEeN6IFa6DxwRt1NNpOdmSpQUfkBj0qeD3m6P77uzMhgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.11",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.3.tgz",
+      "integrity": "sha512-7k4UxjSpHmPN2AxVhvIazRSzFQjWnud3sOsXcFStzagww17j1cFQYqTSiQ8xuYK3vKLR1Ni8FzuT3VlKr3xCNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.9",
+        "@smithy/middleware-endpoint": "^4.4.23",
+        "@smithy/middleware-stack": "^4.2.11",
+        "@smithy/protocol-http": "^5.3.11",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-stream": "^4.5.17",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
+      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
+      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.39",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.39.tgz",
+      "integrity": "sha512-ui7/Ho/+VHqS7Km2wBw4/Ab4RktoiSshgcgpJzC4keFPs6tLJS4IQwbeahxQS3E/w98uq6E1mirCH/id9xIXeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.42",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.42.tgz",
+      "integrity": "sha512-QDA84CWNe8Akpj15ofLO+1N3Rfg8qa2K5uX0y6HnOp4AnRYRgWrKx/xzbYNbVF9ZsyJUYOfcoaN3y93wA/QJ2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.10",
+        "@smithy/credential-provider-imds": "^4.2.11",
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/property-provider": "^4.2.11",
+        "@smithy/smithy-client": "^4.12.3",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
+      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
+      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
+      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
+      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.13",
+        "@smithy/node-http-handler": "^4.4.14",
+        "@smithy/types": "^4.13.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.11.tgz",
+      "integrity": "sha512-x7Rh2azQPs3XxbvCzcttRErKKvLnbZfqRf/gOjw2pb+ZscX88e5UkRPCB67bVnsFHxayvMvmePfKTqsRb+is1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.11",
+        "@smithy/types": "^4.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.0.0",
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
+      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/backend/toytalker-device-setting-lambda/package.json
+++ b/backend/toytalker-device-setting-lambda/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "toytalker-device-setting-lambda",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.mjs",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0"
+  }
+}

--- a/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
@@ -905,7 +905,7 @@ void sendToLambdaAndPlay(const String& text) {
 
   Serial.println("🔊 Playback complete");
 
-  delay(1000);
+  delay(2000);
   Serial.println("🔊 Buffer flushed");
 
   addToHistory("user", text);

--- a/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
@@ -1073,10 +1073,9 @@ void tryConnectWiFiFromBLE(const String& ssid, const String& password) {
 
       sendBLEStatus("CONNECTED");
 
-      // 少し待ってからBLE停止、通常モードへ
+      // NVS保存済みなので再起動して通常モードへ（BLE deinitの詰まり回避）
       delay(1000);
-      stopBLE();
-      startNormalOperation();
+      ESP.restart();
       return;
     }
 

--- a/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
@@ -905,7 +905,7 @@ void sendToLambdaAndPlay(const String& text) {
 
   Serial.println("🔊 Playback complete");
 
-  delay(2000);
+  delay(1500);
   Serial.println("🔊 Buffer flushed");
 
   addToHistory("user", text);

--- a/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
@@ -27,6 +27,7 @@ Preferences preferences;
 #define CHAR_PASSWORD_UUID     "12345678-1234-1234-1234-123456789ab2"
 #define CHAR_COMMAND_UUID      "12345678-1234-1234-1234-123456789ab3"
 #define CHAR_STATUS_UUID       "12345678-1234-1234-1234-123456789ab4"
+#define CHAR_MAC_UUID          "12345678-1234-1234-1234-123456789ab5"
 
 // ==== デバイスモード ====
 enum DeviceMode {
@@ -298,6 +299,13 @@ void startBLE() {
   );
   pStatusChar->addDescriptor(new BLE2902());
   pStatusChar->setValue("READY");
+
+  // MACアドレスキャラクタリスティック（Read only）
+  BLECharacteristic* pMacChar = pService->createCharacteristic(
+    CHAR_MAC_UUID,
+    BLECharacteristic::PROPERTY_READ
+  );
+  pMacChar->setValue(BLEDevice::getAddress().toString().c_str());
 
   pService->start();
 

--- a/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
+++ b/devices/mcu/esp32_s3/toytalk_demo_v2.0/toytalk_demo_v2.0.ino
@@ -42,6 +42,7 @@ BLEServer* pServer = NULL;
 BLECharacteristic* pStatusChar = NULL;
 bool bleDeviceConnected = false;
 bool oldBleDeviceConnected = false;
+String deviceMacAddress = "";
 
 // ==== Lambda (TTS) - Binary Streaming ====
 const char* LAMBDA_HOST = "koufofwm3w4tidbe52crbyhpyq0cshss.lambda-url.ap-northeast-1.on.aws";
@@ -187,6 +188,20 @@ void saveWiFiCredentials(const String& ssid, const String& password) {
   Serial.println("💾 WiFi credentials saved to NVS");
 }
 
+void saveDeviceMac(const String& mac) {
+  preferences.begin("device", false);
+  preferences.putString("mac", mac);
+  preferences.end();
+  Serial.printf("💾 Device MAC saved to NVS: %s\n", mac.c_str());
+}
+
+String loadDeviceMac() {
+  preferences.begin("device", true);
+  String mac = preferences.getString("mac", "");
+  preferences.end();
+  return mac;
+}
+
 bool loadWiFiCredentials() {
   preferences.begin("wifi", true);
   wifiSSID = preferences.getString("ssid", "");
@@ -305,7 +320,8 @@ void startBLE() {
     CHAR_MAC_UUID,
     BLECharacteristic::PROPERTY_READ
   );
-  pMacChar->setValue(BLEDevice::getAddress().toString().c_str());
+  deviceMacAddress = BLEDevice::getAddress().toString().c_str();
+  pMacChar->setValue(deviceMacAddress.c_str());
 
   pService->start();
 
@@ -825,6 +841,7 @@ void sendToLambdaAndPlay(const String& text) {
 
   String payload =
     "{\"model\":\"" + String(TTS_PROVIDER) + "\",\"voice\":\"" + String(TTS_CHARACTER) + "\","
+    "\"device_id\":\"" + deviceMacAddress + "\","
     "\"messages\":" + messagesJson + "}";
 
   Serial.printf("📝 History count: %d\n", historyCount);
@@ -1050,6 +1067,10 @@ void tryConnectWiFiFromBLE(const String& ssid, const String& password) {
       wifiSSID = ssid;
       wifiPassword = password;
 
+      // BLE MACをNVSに保存（以降の起動でdevice_idとして使用）
+      deviceMacAddress = BLEDevice::getAddress().toString().c_str();
+      saveDeviceMac(deviceMacAddress);
+
       sendBLEStatus("CONNECTED");
 
       // 少し待ってからBLE停止、通常モードへ
@@ -1120,6 +1141,12 @@ void setup() {
   // LED初期化（PWM使用 - 新API）
   ledcAttach(PIN_LED, LED_FREQ, LED_RESOLUTION);
   setLEDMode(LED_ON);  // 起動中は点灯
+
+  // NVSからBLE MACアドレスを読み込み（WiFi設定時に保存済みの場合）
+  deviceMacAddress = loadDeviceMac();
+  if (deviceMacAddress.length() > 0) {
+    Serial.printf("📱 Device MAC (from NVS): %s\n", deviceMacAddress.c_str());
+  }
 
   // ボタン初期化
   pinMode(PIN_BUTTON, INPUT_PULLUP);


### PR DESCRIPTION
## Summary
- Extract MODEL_MAP to `app/constants/ModelMap.ts` for shared use
- Add `toytalker-device-setting-lambda` with CRUD endpoints (GET /voices, POST/GET/PUT /devices)
- Seed `toytalker-voices` DynamoDB table with 26 voices (OpenAI/Google/Gemini/ElevenLabs/FishAudio)
- Add BLE MAC address characteristic (CHAR_MAC_UUID) to ESP32 firmware for device identification
- Save BLE MAC to NVS on WiFi setup; load on boot for use as device_id
- Full rework of `toy.tsx`: BLE scan → WiFi setup screen → device registration → voice settings
- Persist registered device via AsyncStorage across app restarts and BLE disconnects
- Add DynamoDB voice config lookup and FishAudio TTS to ESP32 Lambda
- Fix BLE stop hang by using ESP.restart() after WiFi setup success
- Fix deploy.sh: use --external for AWS SDK (ESM, 253KB vs 1.3MB bundle)

## Test plan
- [ ] BLEスキャン → ToyTalkデバイス発見 → タップ → WiFi設定画面へ遷移
- [ ] WiFi設定送信 → ESP32再起動 → 通常動作開始
- [ ] アプリの登録済みデバイス欄にデバイスが表示される
- [ ] デバイスタップ → 設定画面 → ボイス選択 → 即反映（DynamoDB更新）
- [ ] ESP32がDynamoDBのvoice設定を使ってTTS再生
- [ ] アプリ再起動後も登録済みデバイスが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)