### PR TITLE
Add character system

### DIFF
--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -9,16 +9,16 @@ import {
   UIManager,
   TouchableOpacity,
   TextInput,
-  FlatList,
   Alert,
   ActivityIndicator,
   ScrollView,
+  SectionList,
 } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useRef, useState } from "react";
 
 type Pos = { x: number; y: number; w: number };
-type SettingsScreen = "main" | "character-list" | "character-create";
+type SettingsScreen = "main" | "character-list" | "character-edit";
 
 type CharacterItem = {
   character_id: string;
@@ -26,14 +26,23 @@ type CharacterItem = {
   description: string;
   owner_id: string;
   voice_id: string;
+  personality_prompt?: string;
+};
+
+type VoiceItem = {
+  voice_id: string;
+  label: string;
+  provider: string;
+  vendor_id: string;
 };
 
 const DEVICE_SETTING_URL = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
+const PROVIDER_ORDER = ["OpenAI", "Google", "Gemini", "ElevenLabs", "FishAudio"];
 
 const PERSONALITY_TEMPLATES = [
-  { label: "海賊", prompt: "あなたは明るく威勢の良い海賊です。「〜でさあ」「〜じゃな」など海賊らしい口調で話してください。" },
-  { label: "忍者", prompt: "あなたは冷静で謙虚な忍者です。「〜にございます」「〜でござる」など忍者らしい口調で話してください。" },
-  { label: "博士", prompt: "あなたは発明好きの博士です。「〜なのじゃ」「なるほど！」など、知識豊富で熱心な口調で話してください。" },
+  { label: "海賊",   prompt: "あなたは明るく威勢の良い海賊です。「〜でさあ」「〜じゃな」など海賊らしい口調で話してください。" },
+  { label: "忍者",   prompt: "あなたは冷静で謙虚な忍者です。「〜にございます」「〜でござる」など忍者らしい口調で話してください。" },
+  { label: "博士",   prompt: "あなたは発明好きの博士です。「〜なのじゃ」「なるほど！」など、知識豊富で熱心な口調で話してください。" },
   { label: "魔法使い", prompt: "あなたは不思議な魔法使いです。「〜じゃよ」「ふむふむ」など、神秘的で優しい口調で話してください。" },
   { label: "フリー入力", prompt: "" },
 ];
@@ -52,14 +61,20 @@ export default function Settings() {
   const [charsLoading, setCharsLoading] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
-  // キャラクター作成
+  // キャラクター編集（新規作成も兼用）
+  const [editingCharacter, setEditingCharacter] = useState<CharacterItem | null>(null); // null = 新規作成
   const [charName, setCharName] = useState("");
   const [charDesc, setCharDesc] = useState("");
   const [charPrompt, setCharPrompt] = useState("");
+  const [charVoiceId, setCharVoiceId] = useState("elevenlabs_sameno");
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
+  const [saving, setSaving] = useState(false);
 
-  // 起動時に保存値を反映
+  // ボイス一覧
+  const [voices, setVoices] = useState<VoiceItem[]>([]);
+  const [voicesLoading, setVoicesLoading] = useState(false);
+  const [voiceModalVisible, setVoiceModalVisible] = useState(false);
+
   useEffect(() => {
     (async () => {
       const saved = await AsyncStorage.getItem("sttMode");
@@ -67,28 +82,17 @@ export default function Settings() {
     })();
   }, []);
 
+  // ---- STT ドロップダウン ----
   const openDropdown = () => {
-    if (!selectorRef.current) {
-      setDropdownPos(null);
-      setModalVisible(true);
-      return;
-    }
+    if (!selectorRef.current) { setDropdownPos(null); setModalVisible(true); return; }
     const handle = findNodeHandle(selectorRef.current);
-    if (!handle) {
-      setDropdownPos(null);
-      setModalVisible(true);
-      return;
-    }
-
+    if (!handle) { setDropdownPos(null); setModalVisible(true); return; }
     // @ts-ignore
     const measure = (UIManager.measureInWindow ?? UIManager.measure).bind(UIManager);
     measure(handle, (x: number, y: number, width: number, height: number, pageX?: number, pageY?: number) => {
       const absX = typeof pageX === "number" ? pageX : x;
       const absY = typeof pageY === "number" ? pageY : y;
-      const safeW = Number.isFinite(width) && width > 0 ? width : 200;
-      const safeX = Number.isFinite(absX) ? absX : 24;
-      const safeY = Number.isFinite(absY) ? absY : 24;
-      setDropdownPos({ x: safeX, y: safeY + height, w: safeW });
+      setDropdownPos({ x: Number.isFinite(absX) ? absX : 24, y: Number.isFinite(absY) ? absY + height : 24, w: Number.isFinite(width) && width > 0 ? width : 200 });
       setModalVisible(true);
     });
   };
@@ -101,26 +105,20 @@ export default function Settings() {
 
   const renderDropdown = () => {
     if (!modalVisible) return null;
-    const w    = dropdownPos ? Math.max(140, Math.floor(dropdownPos.w * 0.5)) : 220;
-    const top  = dropdownPos ? dropdownPos.y : 200;
-    const left = dropdownPos ? dropdownPos.x : 24;
+    const w = dropdownPos ? Math.max(140, Math.floor(dropdownPos.w * 0.5)) : 220;
     return (
       <Modal transparent visible animationType="fade">
         <Pressable style={s.overlay} onPress={() => setModalVisible(false)}>
-          <View style={[s.dropdown, { top, left, width: w }]}>
-            <Pressable style={s.option} onPress={() => handleSttChange("soniox")}>
-              <Text style={s.optionText}>Soniox STT</Text>
-            </Pressable>
-            <Pressable style={s.option} onPress={() => handleSttChange("local")}>
-              <Text style={s.optionText}>ローカル STT</Text>
-            </Pressable>
+          <View style={[s.dropdown, { top: dropdownPos?.y ?? 200, left: dropdownPos?.x ?? 24, width: w }]}>
+            <Pressable style={s.option} onPress={() => handleSttChange("soniox")}><Text style={s.optionText}>Soniox STT</Text></Pressable>
+            <Pressable style={s.option} onPress={() => handleSttChange("local")}><Text style={s.optionText}>ローカル STT</Text></Pressable>
           </View>
         </Pressable>
       </Modal>
     );
   };
 
-  // ---- キャラクター一覧取得 ----
+  // ---- キャラクター一覧 ----
   const loadCharacters = async () => {
     setCharsLoading(true);
     try {
@@ -134,21 +132,46 @@ export default function Settings() {
     }
   };
 
+  const loadVoices = async () => {
+    setVoicesLoading(true);
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/voices`);
+      const data = await res.json();
+      setVoices(data.voices ?? []);
+    } catch {
+      Alert.alert("エラー", "ボイス一覧の取得に失敗しました");
+    } finally {
+      setVoicesLoading(false);
+    }
+  };
+
   const openCharacterList = () => {
     setScreen("character-list");
     loadCharacters();
   };
 
+  const openCharacterEdit = (character: CharacterItem | null) => {
+    setEditingCharacter(character);
+    setCharName(character?.name ?? "");
+    setCharDesc(character?.description ?? "");
+    setCharPrompt(character?.personality_prompt ?? "");
+    setCharVoiceId(character?.voice_id ?? "elevenlabs_sameno");
+    setSelectedTemplate(null);
+    setScreen("character-edit");
+    loadVoices();
+  };
+
   const deleteCharacter = async (characterId: string) => {
-    Alert.alert("削除確認", "このキャラクターを削除しますか？", [
+    Alert.alert("削除確認", "このキャラクターを削除しますか？\nこの操作は元に戻せません。", [
       { text: "キャンセル", style: "cancel" },
       {
-        text: "削除", style: "destructive",
+        text: "削除する", style: "destructive",
         onPress: async () => {
           setDeletingId(characterId);
           try {
             await fetch(`${DEVICE_SETTING_URL}/characters/${encodeURIComponent(characterId)}`, { method: "DELETE" });
             setCharacters((prev) => prev.filter((c) => c.character_id !== characterId));
+            setScreen("character-list");
           } catch {
             Alert.alert("エラー", "削除に失敗しました");
           } finally {
@@ -157,15 +180,6 @@ export default function Settings() {
         },
       },
     ]);
-  };
-
-  // ---- キャラクター作成 ----
-  const openCharacterCreate = () => {
-    setCharName("");
-    setCharDesc("");
-    setCharPrompt("");
-    setSelectedTemplate(null);
-    setScreen("character-create");
   };
 
   const applyTemplate = (label: string, prompt: string) => {
@@ -178,43 +192,57 @@ export default function Settings() {
     }
   };
 
-  const createCharacter = async () => {
-    if (!charName.trim()) {
-      Alert.alert("エラー", "名前を入力してください");
-      return;
-    }
-    setCreating(true);
+  const saveCharacter = async () => {
+    if (!charName.trim()) { Alert.alert("エラー", "名前を入力してください"); return; }
+    setSaving(true);
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/characters`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: charName.trim(),
-          description: charDesc.trim(),
-          personality_prompt: charPrompt.trim(),
-        }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (editingCharacter) {
+        // 既存キャラ更新
+        const res = await fetch(`${DEVICE_SETTING_URL}/characters/${encodeURIComponent(editingCharacter.character_id)}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      } else {
+        // 新規作成
+        const res = await fetch(`${DEVICE_SETTING_URL}/characters`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      }
       setScreen("character-list");
       loadCharacters();
-    } catch (e: any) {
-      Alert.alert("エラー", "キャラクターの作成に失敗しました");
+    } catch {
+      Alert.alert("エラー", "保存に失敗しました");
     } finally {
-      setCreating(false);
+      setSaving(false);
     }
   };
 
-  // ---- キャラクター作成画面 ----
-  if (screen === "character-create") {
+  // ---- キャラクター編集画面 ----
+  if (screen === "character-edit") {
+    const voiceSections = PROVIDER_ORDER
+      .map((provider) => ({ title: provider, data: voices.filter((v) => v.provider === provider) }))
+      .filter((s) => s.data.length > 0);
+
+    const currentVoiceLabel = () => {
+      const v = voices.find((v) => v.voice_id === charVoiceId);
+      return v ? `${v.label} (${v.provider})` : charVoiceId;
+    };
+
     return (
       <SafeAreaView style={s.root}>
         <View style={s.header}>
           <TouchableOpacity onPress={() => setScreen("character-list")}>
             <Text style={s.back}>← 戻る</Text>
           </TouchableOpacity>
-          <Text style={s.headerTitle}>キャラクター作成</Text>
+          <Text style={s.headerTitle}>{editingCharacter ? "キャラクター編集" : "キャラクター作成"}</Text>
         </View>
         <ScrollView contentContainerStyle={s.wrap}>
+
           <Text style={s.sectionTitle}>テンプレート</Text>
           <View style={s.templateRow}>
             {PERSONALITY_TEMPLATES.map((t) => (
@@ -223,30 +251,16 @@ export default function Settings() {
                 style={[s.templateChip, selectedTemplate === t.label && s.templateChipSelected]}
                 onPress={() => applyTemplate(t.label, t.prompt)}
               >
-                <Text style={[s.templateChipText, selectedTemplate === t.label && s.templateChipTextSelected]}>
-                  {t.label}
-                </Text>
+                <Text style={[s.templateChipText, selectedTemplate === t.label && s.templateChipTextSelected]}>{t.label}</Text>
               </TouchableOpacity>
             ))}
           </View>
 
           <Text style={[s.sectionTitle, { marginTop: 16 }]}>名前 *</Text>
-          <TextInput
-            style={s.input}
-            value={charName}
-            onChangeText={setCharName}
-            placeholder="例：海賊ジャック"
-            autoCorrect={false}
-          />
+          <TextInput style={s.input} value={charName} onChangeText={setCharName} placeholder="例：海賊ジャック" autoCorrect={false} />
 
           <Text style={[s.sectionTitle, { marginTop: 12 }]}>説明</Text>
-          <TextInput
-            style={s.input}
-            value={charDesc}
-            onChangeText={setCharDesc}
-            placeholder="例：勇敢な海賊キャラクター"
-            autoCorrect={false}
-          />
+          <TextInput style={s.input} value={charDesc} onChangeText={setCharDesc} placeholder="例：勇敢な海賊キャラクター" autoCorrect={false} />
 
           <Text style={[s.sectionTitle, { marginTop: 12 }]}>キャラクタープロンプト</Text>
           <TextInput
@@ -259,18 +273,61 @@ export default function Settings() {
             autoCorrect={false}
           />
 
-          <TouchableOpacity
-            style={[s.button, creating && s.buttonDisabled]}
-            onPress={createCharacter}
-            disabled={creating}
-          >
-            {creating ? (
-              <ActivityIndicator color="#fff" />
-            ) : (
-              <Text style={s.buttonText}>作成する</Text>
-            )}
+          <Text style={[s.sectionTitle, { marginTop: 16 }]}>ボイス</Text>
+          <TouchableOpacity style={s.settingRow} onPress={() => setVoiceModalVisible(true)}>
+            <Text style={s.settingRowText}>{voicesLoading ? "読み込み中..." : currentVoiceLabel()}</Text>
+            <Text style={s.chevron}>›</Text>
+          </TouchableOpacity>
+
+          {/* 削除ボタン（カスタムキャラの編集時のみ） */}
+          {editingCharacter && editingCharacter.owner_id !== "system" && (
+            <TouchableOpacity
+              style={[s.buttonDanger, { marginTop: 32 }, deletingId === editingCharacter.character_id && s.buttonDisabled]}
+              onPress={() => deleteCharacter(editingCharacter.character_id)}
+              disabled={deletingId === editingCharacter.character_id}
+            >
+              {deletingId === editingCharacter.character_id
+                ? <ActivityIndicator color="#fff" />
+                : <Text style={s.buttonText}>削除する</Text>}
+            </TouchableOpacity>
+          )}
+
+          <TouchableOpacity style={[s.button, saving && s.buttonDisabled, { marginTop: 12 }]} onPress={saveCharacter} disabled={saving}>
+            {saving ? <ActivityIndicator color="#fff" /> : <Text style={s.buttonText}>{editingCharacter ? "保存する" : "作成する"}</Text>}
           </TouchableOpacity>
         </ScrollView>
+
+        {/* ボイス選択モーダル */}
+        <Modal visible={voiceModalVisible} animationType="slide">
+          <SafeAreaView style={s.root}>
+            <View style={s.header}>
+              <TouchableOpacity onPress={() => setVoiceModalVisible(false)}>
+                <Text style={s.back}>← 閉じる</Text>
+              </TouchableOpacity>
+              <Text style={s.headerTitle}>ボイス選択</Text>
+            </View>
+            <ScrollView contentContainerStyle={{ padding: 16, gap: 8 }}>
+              {voiceSections.map((section) => (
+                <View key={section.title}>
+                  <Text style={s.listSectionHeader}>{section.title}</Text>
+                  {section.data.map((v) => {
+                    const selected = v.voice_id === charVoiceId;
+                    return (
+                      <TouchableOpacity
+                        key={v.voice_id}
+                        style={[s.voiceRow, selected && s.voiceRowSelected]}
+                        onPress={() => { setCharVoiceId(v.voice_id); setVoiceModalVisible(false); }}
+                      >
+                        <View style={[s.radio, selected && s.radioSelected]} />
+                        <Text style={[s.voiceLabel, selected && s.voiceLabelSelected]}>{v.label}</Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              ))}
+            </ScrollView>
+          </SafeAreaView>
+        </Modal>
       </SafeAreaView>
     );
   }
@@ -289,7 +346,7 @@ export default function Settings() {
           <Text style={s.headerTitle}>キャラクター管理</Text>
         </View>
         <ScrollView contentContainerStyle={s.wrap}>
-          <TouchableOpacity style={s.button} onPress={openCharacterCreate}>
+          <TouchableOpacity style={s.button} onPress={() => openCharacterEdit(null)}>
             <Text style={s.buttonText}>＋ キャラクターを作成</Text>
           </TouchableOpacity>
 
@@ -315,29 +372,18 @@ export default function Settings() {
                 <>
                   <Text style={s.listSectionHeader}>カスタム</Text>
                   {userChars.map((c) => (
-                    <View key={c.character_id} style={s.characterCard}>
+                    <TouchableOpacity key={c.character_id} style={s.characterCard} onPress={() => openCharacterEdit(c)}>
                       <View style={{ flex: 1 }}>
                         <Text style={s.characterName}>{c.name}</Text>
                         {c.description ? <Text style={s.characterDesc}>{c.description}</Text> : null}
                       </View>
-                      <TouchableOpacity
-                        onPress={() => deleteCharacter(c.character_id)}
-                        disabled={deletingId === c.character_id}
-                      >
-                        {deletingId === c.character_id ? (
-                          <ActivityIndicator size="small" color="#ff3b30" />
-                        ) : (
-                          <Text style={s.deleteText}>削除</Text>
-                        )}
-                      </TouchableOpacity>
-                    </View>
+                      <Text style={s.chevron}>›</Text>
+                    </TouchableOpacity>
                   ))}
                 </>
               )}
 
-              {characters.length === 0 && (
-                <Text style={s.emptyText}>キャラクターがありません</Text>
-              )}
+              {characters.length === 0 && <Text style={s.emptyText}>キャラクターがありません</Text>}
             </>
           )}
         </ScrollView>
@@ -353,17 +399,13 @@ export default function Settings() {
 
         <Text style={s.item}>・音声認識</Text>
         <Pressable ref={selectorRef} style={s.selector} onPress={openDropdown}>
-          <Text style={s.selectorText}>
-            {sttMode === "local" ? "ローカル STT" : "Soniox STT"}
-          </Text>
+          <Text style={s.selectorText}>{sttMode === "local" ? "ローカル STT" : "Soniox STT"}</Text>
         </Pressable>
-
         {renderDropdown()}
 
         <View style={{ height: 8 }} />
-        <Text style={s.item}>・キャラクター管理</Text>
         <TouchableOpacity style={s.navRow} onPress={openCharacterList}>
-          <Text style={s.navText}>キャラクターを管理</Text>
+          <Text style={s.navText}>キャラクター管理</Text>
           <Text style={s.chevron}>›</Text>
         </TouchableOpacity>
 
@@ -387,29 +429,13 @@ const s = StyleSheet.create({
   wrap:                    { padding: 20, gap: 12 },
   title:                   { fontSize: 20, fontWeight: "700" },
   item:                    { fontSize: 16, color: "#444" },
-  selector: {
-    marginTop: 8,
-    paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderWidth: 1,
-    borderColor: "#999",
-    borderRadius: 6,
-    backgroundColor: "#f9f9f9",
-    width: "50%",
-  },
+  selector:                { marginTop: 8, paddingVertical: 6, paddingHorizontal: 12, borderWidth: 1, borderColor: "#999", borderRadius: 6, backgroundColor: "#f9f9f9", width: "50%" },
   selectorText:            { fontSize: 16 },
   overlay:                 { flex: 1 },
-  dropdown: {
-    position: "absolute",
-    backgroundColor: "#fff",
-    borderWidth: 1,
-    borderColor: "#ccc",
-    borderRadius: 6,
-    elevation: 3,
-  },
+  dropdown:                { position: "absolute", backgroundColor: "#fff", borderWidth: 1, borderColor: "#ccc", borderRadius: 6, elevation: 3 },
   option:                  { paddingVertical: 8, paddingHorizontal: 12 },
   optionText:              { fontSize: 16 },
-  // キャラクター管理
+  // ナビゲーション
   navRow:                  { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 12, paddingHorizontal: 16, backgroundColor: "#f9f9f9", borderRadius: 8, borderWidth: 1, borderColor: "#e0e0e0" },
   navText:                 { fontSize: 16, color: "#333" },
   chevron:                 { fontSize: 20, color: "#999" },
@@ -419,12 +445,14 @@ const s = StyleSheet.create({
   back:                    { fontSize: 16, color: "#007AFF" },
   // キャラクター一覧
   listSectionHeader:       { fontSize: 13, fontWeight: "700", color: "#555", marginTop: 16, marginBottom: 6, textTransform: "uppercase" },
-  characterCard:           { flexDirection: "row", alignItems: "center", backgroundColor: "#f9f9f9", padding: 14, borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0" },
+  characterCard:           { flexDirection: "row", alignItems: "center", backgroundColor: "#f9f9f9", padding: 14, borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0", gap: 8 },
   characterName:           { fontSize: 15, fontWeight: "600" },
   characterDesc:           { fontSize: 12, color: "#888", marginTop: 2 },
+  editButton:              { paddingHorizontal: 8 },
+  editText:                { fontSize: 14, color: "#007AFF" },
   deleteText:              { fontSize: 14, color: "#ff3b30", paddingHorizontal: 8 },
   emptyText:               { fontSize: 15, color: "#999", textAlign: "center", marginTop: 32 },
-  // キャラクター作成
+  // キャラクター編集
   sectionTitle:            { fontSize: 14, fontWeight: "600", color: "#333" },
   templateRow:             { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 8 },
   templateChip:            { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 20, borderWidth: 1, borderColor: "#ccc", backgroundColor: "#f9f9f9" },
@@ -433,7 +461,21 @@ const s = StyleSheet.create({
   templateChipTextSelected:{ color: "#007AFF", fontWeight: "600" },
   input:                   { backgroundColor: "#fff", padding: 12, borderRadius: 8, borderWidth: 1, borderColor: "#ddd", fontSize: 15, marginTop: 6 },
   inputMultiline:          { height: 100, textAlignVertical: "top" },
+  // ボイス選択
+  currentVoiceBox:         { backgroundColor: "#f0f7ff", padding: 10, borderRadius: 8, marginTop: 6 },
+  currentVoiceText:        { fontSize: 14, color: "#007AFF" },
+  voiceRow:                { flexDirection: "row", alignItems: "center", gap: 10, padding: 12, borderRadius: 8, marginBottom: 6, backgroundColor: "#f9f9f9", borderWidth: 1, borderColor: "#e0e0e0" },
+  voiceRowSelected:        { borderColor: "#007AFF", backgroundColor: "#f0f7ff" },
+  radio:                   { width: 18, height: 18, borderRadius: 9, borderWidth: 2, borderColor: "#ccc" },
+  radioSelected:           { borderColor: "#007AFF", backgroundColor: "#007AFF" },
+  voiceLabel:              { fontSize: 14, color: "#333" },
+  voiceLabelSelected:      { color: "#007AFF", fontWeight: "600" },
+  // ボイス選択行
+  settingRow:              { flexDirection: "row", alignItems: "center", justifyContent: "space-between", padding: 14, backgroundColor: "#f9f9f9", borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0", marginTop: 6 },
+  settingRowText:          { fontSize: 15, color: "#333" },
+  // ボタン
   button:                  { backgroundColor: "#007AFF", padding: 16, borderRadius: 12, alignItems: "center" },
+  buttonDanger:            { backgroundColor: "#ff3b30", padding: 16, borderRadius: 12, alignItems: "center" },
   buttonDisabled:          { backgroundColor: "#999" },
   buttonText:              { color: "#fff", fontSize: 16, fontWeight: "600" },
 });

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -307,12 +307,12 @@ export default function Settings() {
           <Text style={[s.sectionTitle, { marginTop: 12 }]}>説明</Text>
           <TextInput style={s.input} value={charDesc} onChangeText={setCharDesc} placeholder="例：勇敢な海賊キャラクター" autoCorrect={false} />
 
-          <Text style={[s.sectionTitle, { marginTop: 12 }]}>キャラクタープロンプト</Text>
+          <Text style={[s.sectionTitle, { marginTop: 12 }]}>性格・口調</Text>
           <TextInput
             style={[s.input, s.inputMultiline]}
             value={charPrompt}
             onChangeText={setCharPrompt}
-            placeholder="キャラクターの口調・性格を自由に記述..."
+            placeholder="キャラクターの性格や口調を自由に記述..."
             multiline
             numberOfLines={4}
             autoCorrect={false}

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -231,7 +231,7 @@ export default function Settings() {
       {
         value: "local" as const,
         label: "ローカル STT",
-        description: "端末内で処理するオフライン音声認識。ネットワーク不要で動作します。",
+        description: "端末内で処理するオフライン音声認識で日本語のみ対応。ネットワーク不要で動作します。",
       },
     ];
 

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -7,17 +7,57 @@ import {
   Modal,
   findNodeHandle,
   UIManager,
+  TouchableOpacity,
+  TextInput,
+  FlatList,
+  Alert,
+  ActivityIndicator,
+  ScrollView,
 } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useRef, useState } from "react";
 
 type Pos = { x: number; y: number; w: number };
+type SettingsScreen = "main" | "character-list" | "character-create";
+
+type CharacterItem = {
+  character_id: string;
+  name: string;
+  description: string;
+  owner_id: string;
+  voice_id: string;
+};
+
+const DEVICE_SETTING_URL = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
+
+const PERSONALITY_TEMPLATES = [
+  { label: "海賊", prompt: "あなたは明るく威勢の良い海賊です。「〜でさあ」「〜じゃな」など海賊らしい口調で話してください。" },
+  { label: "忍者", prompt: "あなたは冷静で謙虚な忍者です。「〜にございます」「〜でござる」など忍者らしい口調で話してください。" },
+  { label: "博士", prompt: "あなたは発明好きの博士です。「〜なのじゃ」「なるほど！」など、知識豊富で熱心な口調で話してください。" },
+  { label: "魔法使い", prompt: "あなたは不思議な魔法使いです。「〜じゃよ」「ふむふむ」など、神秘的で優しい口調で話してください。" },
+  { label: "フリー入力", prompt: "" },
+];
 
 export default function Settings() {
+  const [screen, setScreen] = useState<SettingsScreen>("main");
+
+  // STT設定
   const [sttMode, setSttMode] = useState<"local" | "soniox">("soniox");
   const [modalVisible, setModalVisible] = useState(false);
   const [dropdownPos, setDropdownPos] = useState<Pos | null>(null);
   const selectorRef = useRef<any>(null);
+
+  // キャラクター管理
+  const [characters, setCharacters] = useState<CharacterItem[]>([]);
+  const [charsLoading, setCharsLoading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  // キャラクター作成
+  const [charName, setCharName] = useState("");
+  const [charDesc, setCharDesc] = useState("");
+  const [charPrompt, setCharPrompt] = useState("");
+  const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
 
   // 起動時に保存値を反映
   useEffect(() => {
@@ -40,26 +80,20 @@ export default function Settings() {
       return;
     }
 
-    // Modal座標ズレやNaN対策：measureInWindowで取得、最低幅を確保
-    // （失敗したら中央にフォールバック）
     // @ts-ignore
     const measure = (UIManager.measureInWindow ?? UIManager.measure).bind(UIManager);
-
     measure(handle, (x: number, y: number, width: number, height: number, pageX?: number, pageY?: number) => {
-      // measure と measureInWindow の引数差分を吸収
       const absX = typeof pageX === "number" ? pageX : x;
       const absY = typeof pageY === "number" ? pageY : y;
-
       const safeW = Number.isFinite(width) && width > 0 ? width : 200;
       const safeX = Number.isFinite(absX) ? absX : 24;
       const safeY = Number.isFinite(absY) ? absY : 24;
-
       setDropdownPos({ x: safeX, y: safeY + height, w: safeW });
       setModalVisible(true);
     });
   };
 
-  const handleChange = async (value: "local" | "soniox") => {
+  const handleSttChange = async (value: "local" | "soniox") => {
     setSttMode(value);
     await AsyncStorage.setItem("sttMode", value);
     setModalVisible(false);
@@ -67,20 +101,17 @@ export default function Settings() {
 
   const renderDropdown = () => {
     if (!modalVisible) return null;
-
-    // 位置が未解決なら画面中央にフォールバック
-    const w = dropdownPos ? Math.max(140, Math.floor(dropdownPos.w * 0.5)) : 220;
-    const top = dropdownPos ? dropdownPos.y : 200;
+    const w    = dropdownPos ? Math.max(140, Math.floor(dropdownPos.w * 0.5)) : 220;
+    const top  = dropdownPos ? dropdownPos.y : 200;
     const left = dropdownPos ? dropdownPos.x : 24;
-
     return (
       <Modal transparent visible animationType="fade">
         <Pressable style={s.overlay} onPress={() => setModalVisible(false)}>
           <View style={[s.dropdown, { top, left, width: w }]}>
-            <Pressable style={s.option} onPress={() => handleChange("soniox")}>
+            <Pressable style={s.option} onPress={() => handleSttChange("soniox")}>
               <Text style={s.optionText}>Soniox STT</Text>
             </Pressable>
-            <Pressable style={s.option} onPress={() => handleChange("local")}>
+            <Pressable style={s.option} onPress={() => handleSttChange("local")}>
               <Text style={s.optionText}>ローカル STT</Text>
             </Pressable>
           </View>
@@ -89,9 +120,235 @@ export default function Settings() {
     );
   };
 
+  // ---- キャラクター一覧取得 ----
+  const loadCharacters = async () => {
+    setCharsLoading(true);
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/characters`);
+      const data = await res.json();
+      setCharacters(data.characters ?? []);
+    } catch {
+      Alert.alert("エラー", "キャラクター一覧の取得に失敗しました");
+    } finally {
+      setCharsLoading(false);
+    }
+  };
+
+  const openCharacterList = () => {
+    setScreen("character-list");
+    loadCharacters();
+  };
+
+  const deleteCharacter = async (characterId: string) => {
+    Alert.alert("削除確認", "このキャラクターを削除しますか？", [
+      { text: "キャンセル", style: "cancel" },
+      {
+        text: "削除", style: "destructive",
+        onPress: async () => {
+          setDeletingId(characterId);
+          try {
+            await fetch(`${DEVICE_SETTING_URL}/characters/${encodeURIComponent(characterId)}`, { method: "DELETE" });
+            setCharacters((prev) => prev.filter((c) => c.character_id !== characterId));
+          } catch {
+            Alert.alert("エラー", "削除に失敗しました");
+          } finally {
+            setDeletingId(null);
+          }
+        },
+      },
+    ]);
+  };
+
+  // ---- キャラクター作成 ----
+  const openCharacterCreate = () => {
+    setCharName("");
+    setCharDesc("");
+    setCharPrompt("");
+    setSelectedTemplate(null);
+    setScreen("character-create");
+  };
+
+  const applyTemplate = (label: string, prompt: string) => {
+    setSelectedTemplate(label);
+    if (label !== "フリー入力") {
+      setCharPrompt(prompt);
+      if (!charName) setCharName(label);
+    } else {
+      setCharPrompt("");
+    }
+  };
+
+  const createCharacter = async () => {
+    if (!charName.trim()) {
+      Alert.alert("エラー", "名前を入力してください");
+      return;
+    }
+    setCreating(true);
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/characters`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: charName.trim(),
+          description: charDesc.trim(),
+          personality_prompt: charPrompt.trim(),
+        }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setScreen("character-list");
+      loadCharacters();
+    } catch (e: any) {
+      Alert.alert("エラー", "キャラクターの作成に失敗しました");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // ---- キャラクター作成画面 ----
+  if (screen === "character-create") {
+    return (
+      <SafeAreaView style={s.root}>
+        <View style={s.header}>
+          <TouchableOpacity onPress={() => setScreen("character-list")}>
+            <Text style={s.back}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={s.headerTitle}>キャラクター作成</Text>
+        </View>
+        <ScrollView contentContainerStyle={s.wrap}>
+          <Text style={s.sectionTitle}>テンプレート</Text>
+          <View style={s.templateRow}>
+            {PERSONALITY_TEMPLATES.map((t) => (
+              <TouchableOpacity
+                key={t.label}
+                style={[s.templateChip, selectedTemplate === t.label && s.templateChipSelected]}
+                onPress={() => applyTemplate(t.label, t.prompt)}
+              >
+                <Text style={[s.templateChipText, selectedTemplate === t.label && s.templateChipTextSelected]}>
+                  {t.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <Text style={[s.sectionTitle, { marginTop: 16 }]}>名前 *</Text>
+          <TextInput
+            style={s.input}
+            value={charName}
+            onChangeText={setCharName}
+            placeholder="例：海賊ジャック"
+            autoCorrect={false}
+          />
+
+          <Text style={[s.sectionTitle, { marginTop: 12 }]}>説明</Text>
+          <TextInput
+            style={s.input}
+            value={charDesc}
+            onChangeText={setCharDesc}
+            placeholder="例：勇敢な海賊キャラクター"
+            autoCorrect={false}
+          />
+
+          <Text style={[s.sectionTitle, { marginTop: 12 }]}>キャラクタープロンプト</Text>
+          <TextInput
+            style={[s.input, s.inputMultiline]}
+            value={charPrompt}
+            onChangeText={setCharPrompt}
+            placeholder="キャラクターの口調・性格を自由に記述..."
+            multiline
+            numberOfLines={4}
+            autoCorrect={false}
+          />
+
+          <TouchableOpacity
+            style={[s.button, creating && s.buttonDisabled]}
+            onPress={createCharacter}
+            disabled={creating}
+          >
+            {creating ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={s.buttonText}>作成する</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  // ---- キャラクター一覧画面 ----
+  if (screen === "character-list") {
+    const systemChars = characters.filter((c) => c.owner_id === "system");
+    const userChars   = characters.filter((c) => c.owner_id !== "system");
+
+    return (
+      <SafeAreaView style={s.root}>
+        <View style={s.header}>
+          <TouchableOpacity onPress={() => setScreen("main")}>
+            <Text style={s.back}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={s.headerTitle}>キャラクター管理</Text>
+        </View>
+        <ScrollView contentContainerStyle={s.wrap}>
+          <TouchableOpacity style={s.button} onPress={openCharacterCreate}>
+            <Text style={s.buttonText}>＋ キャラクターを作成</Text>
+          </TouchableOpacity>
+
+          {charsLoading ? (
+            <ActivityIndicator size="large" color="#007AFF" style={{ marginTop: 24 }} />
+          ) : (
+            <>
+              {systemChars.length > 0 && (
+                <>
+                  <Text style={s.listSectionHeader}>システム</Text>
+                  {systemChars.map((c) => (
+                    <View key={c.character_id} style={s.characterCard}>
+                      <View style={{ flex: 1 }}>
+                        <Text style={s.characterName}>{c.name}</Text>
+                        {c.description ? <Text style={s.characterDesc}>{c.description}</Text> : null}
+                      </View>
+                    </View>
+                  ))}
+                </>
+              )}
+
+              {userChars.length > 0 && (
+                <>
+                  <Text style={s.listSectionHeader}>カスタム</Text>
+                  {userChars.map((c) => (
+                    <View key={c.character_id} style={s.characterCard}>
+                      <View style={{ flex: 1 }}>
+                        <Text style={s.characterName}>{c.name}</Text>
+                        {c.description ? <Text style={s.characterDesc}>{c.description}</Text> : null}
+                      </View>
+                      <TouchableOpacity
+                        onPress={() => deleteCharacter(c.character_id)}
+                        disabled={deletingId === c.character_id}
+                      >
+                        {deletingId === c.character_id ? (
+                          <ActivityIndicator size="small" color="#ff3b30" />
+                        ) : (
+                          <Text style={s.deleteText}>削除</Text>
+                        )}
+                      </TouchableOpacity>
+                    </View>
+                  ))}
+                </>
+              )}
+
+              {characters.length === 0 && (
+                <Text style={s.emptyText}>キャラクターがありません</Text>
+              )}
+            </>
+          )}
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  // ---- メイン設定画面 ----
   return (
     <SafeAreaView style={s.root}>
-      <View style={s.wrap}>
+      <ScrollView contentContainerStyle={s.wrap}>
         <Text style={s.title}>設定</Text>
 
         <Text style={s.item}>・音声認識</Text>
@@ -103,8 +360,16 @@ export default function Settings() {
 
         {renderDropdown()}
 
+        <View style={{ height: 8 }} />
+        <Text style={s.item}>・キャラクター管理</Text>
+        <TouchableOpacity style={s.navRow} onPress={openCharacterList}>
+          <Text style={s.navText}>キャラクターを管理</Text>
+          <Text style={s.chevron}>›</Text>
+        </TouchableOpacity>
+
         <View style={{ height: 32 }} />
         <Text style={s.title}>バージョン</Text>
+        <Text style={s.item}>・ver0.7.0   20260309：キャラクターシステム追加</Text>
         <Text style={s.item}>・ver0.6.0   20260306：ボイス追加：ElevenLabs / Fish Audio（※デモ用） </Text>
         <Text style={s.item}>・ver0.5.6   20260210：おもちゃにWIFI設定機能追加</Text>
         <Text style={s.item}>・ver0.5.5   20251005：STT（音声認識）を選択可能にしてリアルタイム表示。スピードも改善</Text>
@@ -112,16 +377,16 @@ export default function Settings() {
         <Text style={s.item}>・ver0.3.0   20250901：マイク機能追加</Text>
         <Text style={s.item}>・ver0.2.0   20250831：会話機能追加。マイクは利用不可</Text>
         <Text style={s.item}>・ver0.1.0   20250830：テストアプリ登録。ホーム/会話/設定画面のみ</Text>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
 
 const s = StyleSheet.create({
-  root: { flex: 1, backgroundColor: "#fff" },
-  wrap: { padding: 20, gap: 12 },
-  title: { fontSize: 20, fontWeight: "700" },
-  item: { fontSize: 16, color: "#444" },
+  root:                    { flex: 1, backgroundColor: "#fff" },
+  wrap:                    { padding: 20, gap: 12 },
+  title:                   { fontSize: 20, fontWeight: "700" },
+  item:                    { fontSize: 16, color: "#444" },
   selector: {
     marginTop: 8,
     paddingVertical: 6,
@@ -132,8 +397,8 @@ const s = StyleSheet.create({
     backgroundColor: "#f9f9f9",
     width: "50%",
   },
-  selectorText: { fontSize: 16 },
-  overlay: { flex: 1 },
+  selectorText:            { fontSize: 16 },
+  overlay:                 { flex: 1 },
   dropdown: {
     position: "absolute",
     backgroundColor: "#fff",
@@ -142,9 +407,33 @@ const s = StyleSheet.create({
     borderRadius: 6,
     elevation: 3,
   },
-  option: {
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-  },
-  optionText: { fontSize: 16 },
+  option:                  { paddingVertical: 8, paddingHorizontal: 12 },
+  optionText:              { fontSize: 16 },
+  // キャラクター管理
+  navRow:                  { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 12, paddingHorizontal: 16, backgroundColor: "#f9f9f9", borderRadius: 8, borderWidth: 1, borderColor: "#e0e0e0" },
+  navText:                 { fontSize: 16, color: "#333" },
+  chevron:                 { fontSize: 20, color: "#999" },
+  // ヘッダー
+  header:                  { flexDirection: "row", alignItems: "center", padding: 16, gap: 12, backgroundColor: "#fff", borderBottomWidth: 1, borderBottomColor: "#e0e0e0" },
+  headerTitle:             { fontSize: 18, fontWeight: "600" },
+  back:                    { fontSize: 16, color: "#007AFF" },
+  // キャラクター一覧
+  listSectionHeader:       { fontSize: 13, fontWeight: "700", color: "#555", marginTop: 16, marginBottom: 6, textTransform: "uppercase" },
+  characterCard:           { flexDirection: "row", alignItems: "center", backgroundColor: "#f9f9f9", padding: 14, borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0" },
+  characterName:           { fontSize: 15, fontWeight: "600" },
+  characterDesc:           { fontSize: 12, color: "#888", marginTop: 2 },
+  deleteText:              { fontSize: 14, color: "#ff3b30", paddingHorizontal: 8 },
+  emptyText:               { fontSize: 15, color: "#999", textAlign: "center", marginTop: 32 },
+  // キャラクター作成
+  sectionTitle:            { fontSize: 14, fontWeight: "600", color: "#333" },
+  templateRow:             { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 8 },
+  templateChip:            { paddingVertical: 6, paddingHorizontal: 14, borderRadius: 20, borderWidth: 1, borderColor: "#ccc", backgroundColor: "#f9f9f9" },
+  templateChipSelected:    { borderColor: "#007AFF", backgroundColor: "#e8f4ff" },
+  templateChipText:        { fontSize: 14, color: "#555" },
+  templateChipTextSelected:{ color: "#007AFF", fontWeight: "600" },
+  input:                   { backgroundColor: "#fff", padding: 12, borderRadius: 8, borderWidth: 1, borderColor: "#ddd", fontSize: 15, marginTop: 6 },
+  inputMultiline:          { height: 100, textAlignVertical: "top" },
+  button:                  { backgroundColor: "#007AFF", padding: 16, borderRadius: 12, alignItems: "center" },
+  buttonDisabled:          { backgroundColor: "#999" },
+  buttonText:              { color: "#fff", fontSize: 16, fontWeight: "600" },
 });

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -3,22 +3,17 @@ import {
   Text,
   View,
   StyleSheet,
-  Pressable,
   Modal,
-  findNodeHandle,
-  UIManager,
   TouchableOpacity,
   TextInput,
   Alert,
   ActivityIndicator,
   ScrollView,
-  SectionList,
 } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useRef, useState } from "react";
 
-type Pos = { x: number; y: number; w: number };
-type SettingsScreen = "main" | "character-list" | "character-edit";
+type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit";
 
 type CharacterItem = {
   character_id: string;
@@ -52,9 +47,6 @@ export default function Settings() {
 
   // STT設定
   const [sttMode, setSttMode] = useState<"local" | "soniox">("soniox");
-  const [modalVisible, setModalVisible] = useState(false);
-  const [dropdownPos, setDropdownPos] = useState<Pos | null>(null);
-  const selectorRef = useRef<any>(null);
 
   // キャラクター管理
   const [characters, setCharacters] = useState<CharacterItem[]>([]);
@@ -82,40 +74,10 @@ export default function Settings() {
     })();
   }, []);
 
-  // ---- STT ドロップダウン ----
-  const openDropdown = () => {
-    if (!selectorRef.current) { setDropdownPos(null); setModalVisible(true); return; }
-    const handle = findNodeHandle(selectorRef.current);
-    if (!handle) { setDropdownPos(null); setModalVisible(true); return; }
-    // @ts-ignore
-    const measure = (UIManager.measureInWindow ?? UIManager.measure).bind(UIManager);
-    measure(handle, (x: number, y: number, width: number, height: number, pageX?: number, pageY?: number) => {
-      const absX = typeof pageX === "number" ? pageX : x;
-      const absY = typeof pageY === "number" ? pageY : y;
-      setDropdownPos({ x: Number.isFinite(absX) ? absX : 24, y: Number.isFinite(absY) ? absY + height : 24, w: Number.isFinite(width) && width > 0 ? width : 200 });
-      setModalVisible(true);
-    });
-  };
-
   const handleSttChange = async (value: "local" | "soniox") => {
     setSttMode(value);
     await AsyncStorage.setItem("sttMode", value);
-    setModalVisible(false);
-  };
-
-  const renderDropdown = () => {
-    if (!modalVisible) return null;
-    const w = dropdownPos ? Math.max(140, Math.floor(dropdownPos.w * 0.5)) : 220;
-    return (
-      <Modal transparent visible animationType="fade">
-        <Pressable style={s.overlay} onPress={() => setModalVisible(false)}>
-          <View style={[s.dropdown, { top: dropdownPos?.y ?? 200, left: dropdownPos?.x ?? 24, width: w }]}>
-            <Pressable style={s.option} onPress={() => handleSttChange("soniox")}><Text style={s.optionText}>Soniox STT</Text></Pressable>
-            <Pressable style={s.option} onPress={() => handleSttChange("local")}><Text style={s.optionText}>ローカル STT</Text></Pressable>
-          </View>
-        </Pressable>
-      </Modal>
-    );
+    setScreen("main");
   };
 
   // ---- キャラクター一覧 ----
@@ -221,6 +183,53 @@ export default function Settings() {
       setSaving(false);
     }
   };
+
+  // ---- STT 選択画面 ----
+  if (screen === "stt-select") {
+    const STT_OPTIONS = [
+      {
+        value: "soniox" as const,
+        label: "Soniox STT",
+        description: "デフォルトで推奨。クラウドベースの高精度な音声認識で多言語に対応。高速なリアルタイム文字起こしができます。",
+      },
+      {
+        value: "local" as const,
+        label: "ローカル STT",
+        description: "端末内で処理するオフライン音声認識。ネットワーク不要で動作します。",
+      },
+    ];
+
+    return (
+      <SafeAreaView style={s.root}>
+        <View style={s.header}>
+          <TouchableOpacity onPress={() => setScreen("main")}>
+            <Text style={s.back}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={s.headerTitle}>音声認識</Text>
+        </View>
+        <View style={s.wrap}>
+          {STT_OPTIONS.map((opt) => {
+            const selected = sttMode === opt.value;
+            return (
+              <TouchableOpacity
+                key={opt.value}
+                style={[s.sttOption, selected && s.sttOptionSelected]}
+                onPress={() => handleSttChange(opt.value)}
+              >
+                <View style={s.sttOptionRow}>
+                  <View style={[s.radio, selected && s.radioSelected]} />
+                  <View style={{ flex: 1 }}>
+                    <Text style={[s.sttLabel, selected && s.sttLabelSelected]}>{opt.label}</Text>
+                    <Text style={s.sttDesc}>{opt.description}</Text>
+                  </View>
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   // ---- キャラクター編集画面 ----
   if (screen === "character-edit") {
@@ -397,11 +406,10 @@ export default function Settings() {
       <ScrollView contentContainerStyle={s.wrap}>
         <Text style={s.title}>設定</Text>
 
-        <Text style={s.item}>・音声認識</Text>
-        <Pressable ref={selectorRef} style={s.selector} onPress={openDropdown}>
-          <Text style={s.selectorText}>{sttMode === "local" ? "ローカル STT" : "Soniox STT"}</Text>
-        </Pressable>
-        {renderDropdown()}
+        <TouchableOpacity style={s.navRow} onPress={() => setScreen("stt-select")}>
+          <Text style={s.navText}>音声認識</Text>
+          <Text style={s.chevron}>›</Text>
+        </TouchableOpacity>
 
         <View style={{ height: 8 }} />
         <TouchableOpacity style={s.navRow} onPress={openCharacterList}>
@@ -429,12 +437,13 @@ const s = StyleSheet.create({
   wrap:                    { padding: 20, gap: 12 },
   title:                   { fontSize: 20, fontWeight: "700" },
   item:                    { fontSize: 16, color: "#444" },
-  selector:                { marginTop: 8, paddingVertical: 6, paddingHorizontal: 12, borderWidth: 1, borderColor: "#999", borderRadius: 6, backgroundColor: "#f9f9f9", width: "50%" },
-  selectorText:            { fontSize: 16 },
-  overlay:                 { flex: 1 },
-  dropdown:                { position: "absolute", backgroundColor: "#fff", borderWidth: 1, borderColor: "#ccc", borderRadius: 6, elevation: 3 },
-  option:                  { paddingVertical: 8, paddingHorizontal: 12 },
-  optionText:              { fontSize: 16 },
+  // STT選択
+  sttOption:               { backgroundColor: "#f9f9f9", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0" },
+  sttOptionSelected:       { borderColor: "#007AFF", backgroundColor: "#f0f7ff" },
+  sttOptionRow:            { flexDirection: "row", alignItems: "flex-start", gap: 12 },
+  sttLabel:                { fontSize: 16, fontWeight: "600", color: "#333" },
+  sttLabelSelected:        { color: "#007AFF" },
+  sttDesc:                 { fontSize: 13, color: "#888", marginTop: 4 },
   // ナビゲーション
   navRow:                  { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 12, paddingHorizontal: 16, backgroundColor: "#f9f9f9", borderRadius: 8, borderWidth: 1, borderColor: "#e0e0e0" },
   navText:                 { fontSize: 16, color: "#333" },

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -13,7 +13,7 @@ import {
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useRef, useState } from "react";
 
-type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit";
+type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "version";
 
 type CharacterItem = {
   character_id: string;
@@ -183,6 +183,42 @@ export default function Settings() {
       setSaving(false);
     }
   };
+
+  // ---- バージョン情報画面 ----
+  if (screen === "version") {
+    return (
+      <SafeAreaView style={s.root}>
+        <View style={s.header}>
+          <TouchableOpacity onPress={() => setScreen("main")}>
+            <Text style={s.back}>← 戻る</Text>
+          </TouchableOpacity>
+          <Text style={s.headerTitle}>バージョン情報</Text>
+        </View>
+        <ScrollView contentContainerStyle={s.wrap}>
+          {[
+            { ver: "0.7.0", date: "20260309", desc: "キャラクターシステム追加" },
+            { ver: "0.6.0", date: "20260306", desc: "ボイス追加：ElevenLabs / Fish Audio（※デモ用）" },
+            { ver: "0.5.6", date: "20260210", desc: "おもちゃにWIFI設定機能追加" },
+            { ver: "0.5.5", date: "20251005", desc: "STT（音声認識）を選択可能にしてリアルタイム表示。スピードも改善" },
+            { ver: "0.4.2", date: "20250907", desc: "ボイス追加：Google TTS / Gemini Speech Generation" },
+            { ver: "0.3.0", date: "20250901", desc: "マイク機能追加" },
+            { ver: "0.2.0", date: "20250831", desc: "会話機能追加。マイクは利用不可" },
+            { ver: "0.1.0", date: "20250830", desc: "テストアプリ登録。ホーム/会話/設定画面のみ" },
+          ].map((v) => (
+            <View key={v.ver} style={s.versionRow}>
+              <View style={s.versionBadge}>
+                <Text style={s.versionBadgeText}>v{v.ver}</Text>
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={s.versionDate}>{v.date}</Text>
+                <Text style={s.versionDesc}>{v.desc}</Text>
+              </View>
+            </View>
+          ))}
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
 
   // ---- STT 選択画面 ----
   if (screen === "stt-select") {
@@ -403,30 +439,22 @@ export default function Settings() {
   // ---- メイン設定画面 ----
   return (
     <SafeAreaView style={s.root}>
+      <View style={[s.header, { justifyContent: "space-between" }]}>
+        <Text style={s.pageTitle}>設定</Text>
+        <TouchableOpacity onPress={() => setScreen("version")}>
+          <Text style={s.versionChip}>Version</Text>
+        </TouchableOpacity>
+      </View>
       <ScrollView contentContainerStyle={s.wrap}>
-        <Text style={s.title}>設定</Text>
-
         <TouchableOpacity style={s.navRow} onPress={() => setScreen("stt-select")}>
           <Text style={s.navText}>音声認識</Text>
           <Text style={s.chevron}>›</Text>
         </TouchableOpacity>
 
-        <View style={{ height: 8 }} />
         <TouchableOpacity style={s.navRow} onPress={openCharacterList}>
           <Text style={s.navText}>キャラクター管理</Text>
           <Text style={s.chevron}>›</Text>
         </TouchableOpacity>
-
-        <View style={{ height: 32 }} />
-        <Text style={s.title}>バージョン</Text>
-        <Text style={s.item}>・ver0.7.0   20260309：キャラクターシステム追加</Text>
-        <Text style={s.item}>・ver0.6.0   20260306：ボイス追加：ElevenLabs / Fish Audio（※デモ用） </Text>
-        <Text style={s.item}>・ver0.5.6   20260210：おもちゃにWIFI設定機能追加</Text>
-        <Text style={s.item}>・ver0.5.5   20251005：STT（音声認識）を選択可能にしてリアルタイム表示。スピードも改善</Text>
-        <Text style={s.item}>・ver0.4.2   20250907：ボイス追加：Google TTS/Gemini Speech Generation</Text>
-        <Text style={s.item}>・ver0.3.0   20250901：マイク機能追加</Text>
-        <Text style={s.item}>・ver0.2.0   20250831：会話機能追加。マイクは利用不可</Text>
-        <Text style={s.item}>・ver0.1.0   20250830：テストアプリ登録。ホーム/会話/設定画面のみ</Text>
       </ScrollView>
     </SafeAreaView>
   );
@@ -435,8 +463,14 @@ export default function Settings() {
 const s = StyleSheet.create({
   root:                    { flex: 1, backgroundColor: "#fff" },
   wrap:                    { padding: 20, gap: 12 },
-  title:                   { fontSize: 20, fontWeight: "700" },
-  item:                    { fontSize: 16, color: "#444" },
+  pageTitle:               { fontSize: 20, fontWeight: "700" },
+  versionChip:             { fontSize: 13, color: "#007AFF", fontWeight: "600", borderWidth: 1, borderColor: "#007AFF", borderRadius: 12, paddingHorizontal: 10, paddingVertical: 3 },
+  // バージョン情報
+  versionRow:              { flexDirection: "row", alignItems: "flex-start", gap: 12, paddingVertical: 8, borderBottomWidth: 1, borderBottomColor: "#f0f0f0" },
+  versionBadge:            { backgroundColor: "#007AFF", paddingHorizontal: 8, paddingVertical: 3, borderRadius: 6, minWidth: 56, alignItems: "center" },
+  versionBadgeText:        { color: "#fff", fontSize: 12, fontWeight: "700" },
+  versionDate:             { fontSize: 12, color: "#999" },
+  versionDesc:             { fontSize: 14, color: "#333", marginTop: 2 },
   // STT選択
   sttOption:               { backgroundColor: "#f9f9f9", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0" },
   sttOptionSelected:       { borderColor: "#007AFF", backgroundColor: "#f0f7ff" },

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -7,7 +7,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   TextInput,
-  SectionList,
+  FlatList,
   Alert,
   ActivityIndicator,
   Platform,
@@ -24,41 +24,42 @@ const CHAR_COMMAND_UUID  = "12345678-1234-1234-1234-123456789ab3";
 const CHAR_STATUS_UUID   = "12345678-1234-1234-1234-123456789ab4";
 const CHAR_MAC_UUID      = "12345678-1234-1234-1234-123456789ab5";
 
-const DEVICE_SETTING_URL  = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
-const DEFAULT_VOICE_ID    = "elevenlabs_sameno";
-const PROVIDER_ORDER      = ["OpenAI", "Google", "Gemini", "ElevenLabs", "FishAudio"];
+const DEVICE_SETTING_URL   = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
+const DEFAULT_CHARACTER_ID = "default";
 
 const bleManager = new BleManager();
 
 type ConnectionStatus = "disconnected" | "scanning" | "connecting" | "connected" | "configuring";
-type Screen = "home" | "wifi-setup" | "device-settings" | "voice-select";
+type Screen = "home" | "wifi-setup" | "device-settings" | "character-select";
 
-type VoiceItem = {
+type CharacterItem = {
+  character_id: string;
+  name: string;
+  description: string;
+  owner_id: string;
   voice_id: string;
-  label: string;
-  provider: string;
-  vendor_id: string;
+  personality_prompt?: string;
 };
 
 type RegisteredDevice = {
   device_id: string;
-  voice_id: string | null;
+  character_id: string | null;
   owner_id: string;
 };
 
 export default function Toy() {
-  const [status, setStatus]                     = useState<ConnectionStatus>("disconnected");
-  const [bleDevices, setBleDevices]             = useState<Device[]>([]);
-  const [connectedDevice, setConnectedDevice]   = useState<Device | null>(null);
-  const [ssid, setSsid]                         = useState("");
-  const [password, setPassword]                 = useState("");
-  const [statusMessage, setStatusMessage]       = useState("");
-  const [screen, setScreen]                     = useState<Screen>("home");
-  const [deviceId, setDeviceId]                 = useState<string | null>(null);
-  const [registeredDevice, setRegisteredDevice] = useState<RegisteredDevice | null>(null);
-  const [voices, setVoices]                     = useState<VoiceItem[]>([]);
-  const [voicesLoading, setVoicesLoading]       = useState(false);
-  const [updatingVoice, setUpdatingVoice]       = useState(false);
+  const [status, setStatus]                         = useState<ConnectionStatus>("disconnected");
+  const [bleDevices, setBleDevices]                 = useState<Device[]>([]);
+  const [connectedDevice, setConnectedDevice]       = useState<Device | null>(null);
+  const [ssid, setSsid]                             = useState("");
+  const [password, setPassword]                     = useState("");
+  const [statusMessage, setStatusMessage]           = useState("");
+  const [screen, setScreen]                         = useState<Screen>("home");
+  const [deviceId, setDeviceId]                     = useState<string | null>(null);
+  const [registeredDevice, setRegisteredDevice]     = useState<RegisteredDevice | null>(null);
+  const [characters, setCharacters]                 = useState<CharacterItem[]>([]);
+  const [charactersLoading, setCharactersLoading]   = useState(false);
+  const [updatingCharacter, setUpdatingCharacter]   = useState(false);
 
   useEffect(() => {
     if (Platform.OS === "android") {
@@ -242,58 +243,59 @@ export default function Toy() {
     setScreen("device-settings");
   };
 
-  const openVoiceSelect = async () => {
-    setVoicesLoading(true);
-    setScreen("voice-select");
+  const openCharacterSelect = async () => {
+    setCharactersLoading(true);
+    setScreen("character-select");
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/voices`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/characters`);
       const data = await res.json();
-      setVoices(data.voices ?? []);
+      setCharacters(data.characters ?? []);
     } catch (e: any) {
-      Alert.alert("エラー", "ボイス一覧の取得に失敗しました");
+      Alert.alert("エラー", "キャラクター一覧の取得に失敗しました");
     } finally {
-      setVoicesLoading(false);
+      setCharactersLoading(false);
     }
   };
 
-  const selectVoice = async (voiceId: string) => {
+  const selectCharacter = async (characterId: string) => {
     if (!deviceId) return;
-    setUpdatingVoice(true);
+    setUpdatingCharacter(true);
     try {
       const res = await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(deviceId)}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ voice_id: voiceId }),
+        body: JSON.stringify({ character_id: characterId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       setRegisteredDevice((prev) => {
-        const updated = prev ? { ...prev, voice_id: voiceId } : prev;
+        const updated = prev ? { ...prev, character_id: characterId } : prev;
         if (updated) AsyncStorage.setItem("registeredDevice", JSON.stringify(updated));
         return updated;
       });
       setScreen("device-settings");
     } catch (e: any) {
-      Alert.alert("エラー", "ボイスの更新に失敗しました");
+      Alert.alert("エラー", "キャラクターの更新に失敗しました");
     } finally {
-      setUpdatingVoice(false);
+      setUpdatingCharacter(false);
     }
   };
 
-  const currentVoiceLabel = () => {
-    if (!registeredDevice?.voice_id) return "未設定";
-    const v = voices.find((v) => v.voice_id === registeredDevice.voice_id);
-    return v ? `${v.label} (${v.provider})` : registeredDevice.voice_id;
+  const currentCharacterLabel = () => {
+    if (!registeredDevice?.character_id || registeredDevice.character_id === "default") return "デフォルト";
+    const c = characters.find((c) => c.character_id === registeredDevice.character_id);
+    return c ? c.name : registeredDevice.character_id;
   };
 
-  // ---- ボイス選択画面 ----
-  if (screen === "voice-select") {
-    const currentId = registeredDevice?.voice_id ?? DEFAULT_VOICE_ID;
-    const sections = PROVIDER_ORDER
-      .map((provider) => ({
-        title: provider,
-        data: voices.filter((v) => v.provider === provider),
-      }))
-      .filter((s) => s.data.length > 0);
+  // ---- キャラクター選択画面 ----
+  if (screen === "character-select") {
+    const currentId = registeredDevice?.character_id ?? DEFAULT_CHARACTER_ID;
+    const systemChars = characters.filter((c) => c.owner_id === "system");
+    const userChars   = characters.filter((c) => c.owner_id !== "system");
+
+    const sections = [
+      { title: "システム", data: systemChars },
+      { title: "カスタム", data: userChars },
+    ].filter((s) => s.data.length > 0);
 
     return (
       <SafeAreaView style={s.root}>
@@ -301,34 +303,47 @@ export default function Toy() {
           <TouchableOpacity onPress={() => setScreen("device-settings")}>
             <Text style={s.back}>← 戻る</Text>
           </TouchableOpacity>
-          <Text style={s.headerTitle}>ボイス選択</Text>
+          <Text style={s.headerTitle}>キャラクター選択</Text>
         </View>
-        {voicesLoading || updatingVoice ? (
+        {charactersLoading || updatingCharacter ? (
           <View style={s.center}>
             <ActivityIndicator size="large" color="#007AFF" />
           </View>
         ) : (
-          <SectionList
-            sections={sections}
-            keyExtractor={(item) => item.voice_id}
+          <FlatList
+            data={characters}
+            keyExtractor={(item) => item.character_id}
             contentContainerStyle={{ padding: 16, gap: 8 }}
-            renderSectionHeader={({ section }) => (
-              <Text style={s.sectionHeader}>{section.title}</Text>
-            )}
-            renderItem={({ item }) => {
-              const selected = item.voice_id === currentId;
-              return (
-                <TouchableOpacity
-                  style={[s.voiceItem, selected && s.voiceItemSelected]}
-                  onPress={() => selectVoice(item.voice_id)}
-                >
-                  <View style={s.voiceRow}>
-                    <View style={[s.radio, selected && s.radioSelected]} />
-                    <Text style={[s.voiceLabel, selected && s.voiceLabelSelected]}>{item.label}</Text>
+            ListHeaderComponent={
+              <>
+                {sections.map((section) => (
+                  <View key={section.title}>
+                    <Text style={s.sectionHeader}>{section.title}</Text>
+                    {section.data.map((item) => {
+                      const selected = item.character_id === currentId;
+                      return (
+                        <TouchableOpacity
+                          key={item.character_id}
+                          style={[s.characterItem, selected && s.characterItemSelected]}
+                          onPress={() => selectCharacter(item.character_id)}
+                        >
+                          <View style={s.characterRow}>
+                            <View style={[s.radio, selected && s.radioSelected]} />
+                            <View style={{ flex: 1 }}>
+                              <Text style={[s.characterLabel, selected && s.characterLabelSelected]}>{item.name}</Text>
+                              {item.description ? (
+                                <Text style={s.characterDesc}>{item.description}</Text>
+                              ) : null}
+                            </View>
+                          </View>
+                        </TouchableOpacity>
+                      );
+                    })}
                   </View>
-                </TouchableOpacity>
-              );
-            }}
+                ))}
+              </>
+            }
+            renderItem={() => null}
           />
         )}
       </SafeAreaView>
@@ -347,10 +362,10 @@ export default function Toy() {
         </View>
         <View style={s.wrap}>
           <Text style={s.deviceIdText}>{deviceId}</Text>
-          <TouchableOpacity style={s.settingRow} onPress={openVoiceSelect}>
+          <TouchableOpacity style={s.settingRow} onPress={openCharacterSelect}>
             <View>
-              <Text style={s.settingLabel}>ボイス</Text>
-              <Text style={s.settingValue}>{currentVoiceLabel()}</Text>
+              <Text style={s.settingLabel}>キャラクター</Text>
+              <Text style={s.settingValue}>{currentCharacterLabel()}</Text>
             </View>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
@@ -488,7 +503,7 @@ export default function Toy() {
               <View>
                 <Text style={s.deviceName}>{registeredDevice.device_id}</Text>
                 <Text style={s.deviceSub}>
-                  ボイス: {registeredDevice.voice_id ?? "未設定"}
+                  キャラクター: {registeredDevice.character_id ?? "未設定"}
                 </Text>
               </View>
               <Text style={s.chevron}>›</Text>
@@ -501,44 +516,44 @@ export default function Toy() {
 }
 
 const s = StyleSheet.create({
-  root:               { flex: 1, backgroundColor: "#f5f5f5" },
-  wrap:               { padding: 20, gap: 16 },
-  title:              { fontSize: 24, fontWeight: "700", marginBottom: 8 },
-  subtitle:           { fontSize: 16, fontWeight: "600", marginBottom: 8, color: "#333" },
-  section:            { gap: 8 },
-  statusBox:          { backgroundColor: "#e3f2fd", padding: 12, borderRadius: 8 },
-  statusText:         { fontSize: 14, color: "#1976d2" },
-  button:             { backgroundColor: "#007AFF", padding: 16, borderRadius: 12, alignItems: "center" },
-  buttonDisabled:     { backgroundColor: "#999" },
-  buttonText:         { color: "#fff", fontSize: 16, fontWeight: "600" },
-  buttonSecondary:    { backgroundColor: "#fff", padding: 14, borderRadius: 12, alignItems: "center", borderWidth: 1, borderColor: "#ddd" },
-  buttonTextSecondary:{ color: "#666", fontSize: 16 },
-  deviceItem:         { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0", flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  deviceName:         { fontSize: 15, fontWeight: "600" },
-  deviceSub:          { fontSize: 12, color: "#888", marginTop: 2 },
-  center:             { alignItems: "center", gap: 16, marginTop: 20 },
-  loadingText:        { fontSize: 16, color: "#666" },
-  form:               { gap: 12 },
-  label:              { fontSize: 14, fontWeight: "500", color: "#333" },
-  input:              { backgroundColor: "#fff", padding: 14, borderRadius: 8, borderWidth: 1, borderColor: "#ddd", fontSize: 16 },
-  chevron:            { fontSize: 20, color: "#999" },
+  root:                  { flex: 1, backgroundColor: "#f5f5f5" },
+  wrap:                  { padding: 20, gap: 16 },
+  title:                 { fontSize: 24, fontWeight: "700", marginBottom: 8 },
+  subtitle:              { fontSize: 16, fontWeight: "600", marginBottom: 8, color: "#333" },
+  section:               { gap: 8 },
+  statusBox:             { backgroundColor: "#e3f2fd", padding: 12, borderRadius: 8 },
+  statusText:            { fontSize: 14, color: "#1976d2" },
+  button:                { backgroundColor: "#007AFF", padding: 16, borderRadius: 12, alignItems: "center" },
+  buttonDisabled:        { backgroundColor: "#999" },
+  buttonText:            { color: "#fff", fontSize: 16, fontWeight: "600" },
+  buttonSecondary:       { backgroundColor: "#fff", padding: 14, borderRadius: 12, alignItems: "center", borderWidth: 1, borderColor: "#ddd" },
+  buttonTextSecondary:   { color: "#666", fontSize: 16 },
+  deviceItem:            { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0", flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  deviceName:            { fontSize: 15, fontWeight: "600" },
+  deviceSub:             { fontSize: 12, color: "#888", marginTop: 2 },
+  center:                { alignItems: "center", gap: 16, marginTop: 20 },
+  loadingText:           { fontSize: 16, color: "#666" },
+  form:                  { gap: 12 },
+  label:                 { fontSize: 14, fontWeight: "500", color: "#333" },
+  input:                 { backgroundColor: "#fff", padding: 14, borderRadius: 8, borderWidth: 1, borderColor: "#ddd", fontSize: 16 },
+  chevron:               { fontSize: 20, color: "#999" },
   // ヘッダー
-  header:             { flexDirection: "row", alignItems: "center", padding: 16, gap: 12, backgroundColor: "#fff", borderBottomWidth: 1, borderBottomColor: "#e0e0e0" },
-  headerTitle:        { fontSize: 18, fontWeight: "600" },
-  back:               { fontSize: 16, color: "#007AFF" },
-  deviceIdText:       { fontSize: 12, color: "#999", marginBottom: 4 },
+  header:                { flexDirection: "row", alignItems: "center", padding: 16, gap: 12, backgroundColor: "#fff", borderBottomWidth: 1, borderBottomColor: "#e0e0e0" },
+  headerTitle:           { fontSize: 18, fontWeight: "600" },
+  back:                  { fontSize: 16, color: "#007AFF" },
+  deviceIdText:          { fontSize: 12, color: "#999", marginBottom: 4 },
   // デバイス設定画面
-  settingRow:         { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0", flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-  settingLabel:       { fontSize: 15, fontWeight: "600" },
-  settingValue:       { fontSize: 13, color: "#666", marginTop: 2 },
-  // ボイス選択画面
-  voiceItem:          { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0" },
-  voiceItemSelected:  { borderColor: "#007AFF", backgroundColor: "#f0f7ff" },
-  voiceRow:           { flexDirection: "row", alignItems: "center", gap: 12 },
-  radio:              { width: 20, height: 20, borderRadius: 10, borderWidth: 2, borderColor: "#ccc" },
-  radioSelected:      { borderColor: "#007AFF", backgroundColor: "#007AFF" },
-  voiceLabel:         { fontSize: 15, fontWeight: "500" },
-  voiceLabelSelected: { color: "#007AFF", fontWeight: "600" },
-  voiceProvider:      { fontSize: 12, color: "#888", marginTop: 2 },
-  sectionHeader:      { fontSize: 13, fontWeight: "700", color: "#555", marginTop: 12, marginBottom: 6, textTransform: "uppercase" },
+  settingRow:            { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0", flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  settingLabel:          { fontSize: 15, fontWeight: "600" },
+  settingValue:          { fontSize: 13, color: "#666", marginTop: 2 },
+  // キャラクター選択画面
+  characterItem:         { backgroundColor: "#fff", padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#e0e0e0", marginBottom: 8 },
+  characterItemSelected: { borderColor: "#007AFF", backgroundColor: "#f0f7ff" },
+  characterRow:          { flexDirection: "row", alignItems: "center", gap: 12 },
+  radio:                 { width: 20, height: 20, borderRadius: 10, borderWidth: 2, borderColor: "#ccc" },
+  radioSelected:         { borderColor: "#007AFF", backgroundColor: "#007AFF" },
+  characterLabel:        { fontSize: 15, fontWeight: "500" },
+  characterLabelSelected:{ color: "#007AFF", fontWeight: "600" },
+  characterDesc:         { fontSize: 12, color: "#888", marginTop: 2 },
+  sectionHeader:         { fontSize: 13, fontWeight: "700", color: "#555", marginTop: 12, marginBottom: 6, textTransform: "uppercase" },
 });

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -8,8 +8,9 @@
 
   const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
   const ddb = DynamoDBDocumentClient.from(ddbClient);
-  const DEVICES_TABLE = "toytalker-devices";
-  const VOICES_TABLE  = "toytalker-voices";
+  const DEVICES_TABLE    = "toytalker-devices";
+  const VOICES_TABLE     = "toytalker-voices";
+  const CHARACTERS_TABLE = "toytalker-characters";
 
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -288,14 +289,34 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
     return pcmBuffer;
   }
 
-  // DynamoDBからdevice_idに紐づくvoice設定を解決
-  async function resolveVoiceFromDynamo(deviceId) {
+  // DynamoDBからdevice_idに紐づくキャラクター＆ボイス設定を解決
+  // 解決チェーン: device → character(voice_id + personality_prompt) → voice(provider + vendor_id)
+  async function resolveCharacterFromDynamo(deviceId) {
     try {
       const deviceRes = await ddb.send(new GetCommand({
         TableName: DEVICES_TABLE,
         Key: { device_id: deviceId },
       }));
-      const voiceId = deviceRes.Item?.voice_id;
+      const device = deviceRes.Item;
+      if (!device) return null;
+
+      let voiceId = null;
+      let personalityPrompt = null;
+
+      // character_id があればキャラクターテーブルを参照
+      if (device.character_id && device.character_id !== "default") {
+        const charRes = await ddb.send(new GetCommand({
+          TableName: CHARACTERS_TABLE,
+          Key: { character_id: device.character_id },
+        }));
+        if (charRes.Item) {
+          voiceId = charRes.Item.voice_id ?? null;
+          personalityPrompt = charRes.Item.personality_prompt || null;
+        }
+      }
+
+      // character_id が未設定またはキャラに voice_id がなければ device.voice_id にフォールバック（後方互換）
+      if (!voiceId) voiceId = device.voice_id ?? null;
       if (!voiceId) return null;
 
       const voiceRes = await ddb.send(new GetCommand({
@@ -304,9 +325,13 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       }));
       if (!voiceRes.Item) return null;
 
-      return { provider: voiceRes.Item.provider, vendorId: voiceRes.Item.vendor_id };
+      return {
+        provider: voiceRes.Item.provider,
+        vendorId: voiceRes.Item.vendor_id,
+        personalityPrompt,
+      };
     } catch (e) {
-      console.error("[DynamoDB] resolveVoiceFromDynamo error:", e);
+      console.error("[DynamoDB] resolveCharacterFromDynamo error:", e);
       return null;
     }
   }
@@ -329,18 +354,20 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       return undefined;
     }
 
-    // device_idがあればDynamoDBからボイス設定を取得、なければbodyの値を使う
+    // device_idがあればDynamoDBからキャラクター＆ボイス設定を取得、なければbodyの値を使う
     let modelKey = normalizeModelKey(body.model) ?? MODEL_DEFAULT;
     let voice    = body.voice ?? VOICE_DEFAULT;
+    let personalityPrompt = null;
 
     if (deviceId) {
-      const voiceConfig = await resolveVoiceFromDynamo(deviceId);
-      if (voiceConfig) {
-        modelKey = normalizeModelKey(voiceConfig.provider) ?? modelKey;
-        voice    = voiceConfig.vendorId ?? voice;
-        console.log(`[DynamoDB] device=${deviceId}, provider=${voiceConfig.provider}, vendorId=${voiceConfig.vendorId}`);
+      const charConfig = await resolveCharacterFromDynamo(deviceId);
+      if (charConfig) {
+        modelKey = normalizeModelKey(charConfig.provider) ?? modelKey;
+        voice    = charConfig.vendorId ?? voice;
+        personalityPrompt = charConfig.personalityPrompt;
+        console.log(`[DynamoDB] device=${deviceId}, provider=${charConfig.provider}, vendorId=${charConfig.vendorId}, hasPersonality=${!!personalityPrompt}`);
       } else {
-        console.log(`[DynamoDB] device=${deviceId} not found or no voice set, using defaults`);
+        console.log(`[DynamoDB] device=${deviceId} not found or no character set, using defaults`);
       }
     }
 
@@ -362,10 +389,11 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       sendMeta(res, "mark", { k: "llm_start", t: Date.now() });
     }
 
-    // システムプロンプトを追加（会話履歴がある場合は挨拶を省略）
+    // システムプロンプトを追加（キャラクターの個性 + 共通指示）
+    const basePrompt = "あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。";
     const systemPrompt = {
       role: "system",
-      content: "あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。"
+      content: personalityPrompt ? `${personalityPrompt}\n\n${basePrompt}` : basePrompt,
     };
     const messagesWithSystem = [systemPrompt, ...messages];
 

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -2,14 +2,15 @@
 // Handler: index.handler
 // Env: なし（DynamoDBはIAMロールで接続）
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
 
 const client = new DynamoDBClient({ region: "ap-northeast-1" });
 const ddb = DynamoDBDocumentClient.from(client);
 
 // ---- テーブル定義 ----
-const DEVICES_TABLE = "toytalker-devices";
-const VOICES_TABLE  = "toytalker-voices";
+const DEVICES_TABLE    = "toytalker-devices";
+const VOICES_TABLE     = "toytalker-voices";
+const CHARACTERS_TABLE = "toytalker-characters";
 
 const response = (statusCode, body) => ({
   statusCode,
@@ -31,6 +32,56 @@ export const handler = async (event) => {
       return response(200, { voices: result.Items ?? [] });
     }
 
+    // ---- GET /characters ---- キャラクター一覧取得（system + 自分のキャラ）
+    if (method === "GET" && path === "/characters") {
+      const userId = event.queryStringParameters?.owner_id ?? "user_123";
+      const result = await ddb.send(new ScanCommand({
+        TableName: CHARACTERS_TABLE,
+        FilterExpression: "owner_id = :system OR owner_id = :userId",
+        ExpressionAttributeValues: { ":system": "system", ":userId": userId },
+      }));
+      return response(200, { characters: result.Items ?? [] });
+    }
+
+    // ---- POST /characters ---- キャラクター作成
+    if (method === "POST" && path === "/characters") {
+      const body = JSON.parse(event.body ?? "{}");
+      const { name, description = "", personality_prompt = "", voice_id = "elevenlabs_sameno", owner_id = "user_123" } = body;
+      if (!name) return response(400, { error: "name is required" });
+
+      const character_id = `${owner_id}_${Date.now()}`;
+      await ddb.send(new PutCommand({
+        TableName: CHARACTERS_TABLE,
+        Item: {
+          character_id,
+          owner_id,
+          name,
+          description,
+          personality_prompt,
+          voice_id,
+          created_at: new Date().toISOString(),
+        },
+      }));
+      return response(200, { character_id, message: "Character created" });
+    }
+
+    // ---- DELETE /characters/{character_id} ---- キャラクター削除（自分のキャラのみ）
+    if (method === "DELETE" && path.startsWith("/characters/")) {
+      const character_id = decodeURIComponent(path.split("/")[2]);
+      const existing = await ddb.send(new GetCommand({
+        TableName: CHARACTERS_TABLE,
+        Key: { character_id },
+      }));
+      if (!existing.Item) return response(404, { error: "Character not found" });
+      if (existing.Item.owner_id === "system") return response(403, { error: "Cannot delete system character" });
+
+      await ddb.send(new DeleteCommand({
+        TableName: CHARACTERS_TABLE,
+        Key: { character_id },
+      }));
+      return response(200, { message: "Character deleted" });
+    }
+
     // ---- POST /devices ---- デバイス登録
     if (method === "POST" && path === "/devices") {
       const body      = JSON.parse(event.body ?? "{}");
@@ -44,7 +95,6 @@ export const handler = async (event) => {
           device_id,
           owner_id,
           character_id: "default",
-          voice_id: null,
           created_at: now,
           last_seen: now,
         },
@@ -78,23 +128,23 @@ export const handler = async (event) => {
       return response(200, result.Item);
     }
 
-    // ---- PUT /devices/{device_id} ---- ボイス設定更新
+    // ---- PUT /devices/{device_id} ---- キャラクター設定更新
     if (method === "PUT" && path.startsWith("/devices/")) {
       const device_id = decodeURIComponent(path.split("/")[2]);
       const body      = JSON.parse(event.body ?? "{}");
-      const { voice_id } = body;
-      if (!voice_id) return response(400, { error: "voice_id is required" });
+      const { character_id } = body;
+      if (!character_id) return response(400, { error: "character_id is required" });
 
       await ddb.send(new UpdateCommand({
         TableName: DEVICES_TABLE,
         Key: { device_id },
-        UpdateExpression: "SET voice_id = :v, last_seen = :t",
+        UpdateExpression: "SET character_id = :c, last_seen = :t",
         ExpressionAttributeValues: {
-          ":v": voice_id,
+          ":c": character_id,
           ":t": new Date().toISOString(),
         },
       }));
-      return response(200, { device_id, voice_id, message: "Device updated" });
+      return response(200, { device_id, character_id, message: "Device updated" });
     }
 
     return response(404, { error: "Not found" });

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -65,6 +65,32 @@ export const handler = async (event) => {
       return response(200, { character_id, message: "Character created" });
     }
 
+    // ---- PUT /characters/{character_id} ---- キャラクター更新
+    if (method === "PUT" && path.startsWith("/characters/")) {
+      const character_id = decodeURIComponent(path.split("/")[2]);
+      const body = JSON.parse(event.body ?? "{}");
+      const { name, description, personality_prompt, voice_id } = body;
+
+      // name / description は DynamoDB 予約語なので ExpressionAttributeNames でエスケープ
+      const updates = [];
+      const vals = {};
+      const names = {};
+      if (name              !== undefined) { updates.push("#nm = :n");  names["#nm"] = "name";        vals[":n"] = name; }
+      if (description       !== undefined) { updates.push("#ds = :d");  names["#ds"] = "description"; vals[":d"] = description; }
+      if (personality_prompt !== undefined) { updates.push("personality_prompt = :p");                 vals[":p"] = personality_prompt; }
+      if (voice_id          !== undefined) { updates.push("voice_id = :v");                            vals[":v"] = voice_id; }
+      if (updates.length === 0) return response(400, { error: "No fields to update" });
+
+      await ddb.send(new UpdateCommand({
+        TableName: CHARACTERS_TABLE,
+        Key: { character_id },
+        UpdateExpression: "SET " + updates.join(", "),
+        ExpressionAttributeNames: Object.keys(names).length ? names : undefined,
+        ExpressionAttributeValues: vals,
+      }));
+      return response(200, { character_id, message: "Character updated" });
+    }
+
     // ---- DELETE /characters/{character_id} ---- キャラクター削除（自分のキャラのみ）
     if (method === "DELETE" && path.startsWith("/characters/")) {
       const character_id = decodeURIComponent(path.split("/")[2]);


### PR DESCRIPTION
## Summary

- `toytalker-characters` DynamoDB テーブルを追加し、キャラクターシステムを実装
- デバイスの `voice_id` → `character_id` に移行（後方互換あり）
- キャラクターごとに personality_prompt を設定でき、LLM のシステムプロンプトに反映
- システムキャラクター5種をシード済み（デフォルト・海賊・忍者・博士・魔法使い）

## 変更内容

- **toytalker-device-setting-lambda**: GET/POST/PUT/DELETE `/characters` エンドポイント追加、PUT `/devices` を `character_id` に更新
- **toytalk-api-stream-for-esp32-lambda**: device→character→voice の解決チェーン、personality_prompt をシステムプロンプトに注入
- **toy.tsx**: ボイス選択 → キャラクター選択に変更
- **settings.tsx**: キャラクター管理画面（一覧・作成・編集・削除・ボイス選択）、設定画面UI全面リファクタ（STT選択画面、バージョン情報画面を独立）

## Test plan

- [ ] アプリ: 設定 → キャラクター管理 → 一覧表示・作成・編集・削除
- [ ] アプリ: おもちゃ → デバイス設定 → キャラクター選択
- [ ] ESP32: キャラクター変更後に口調が変わることを確認
- [ ] 設定: 音声認識選択画面、バージョン情報画面

🤖 Generated with [Claude Code](https://claude.com/claude-code)