### PR TITLE
Replace hardcoded user_123 with UUID-based owner_id

### DIFF
--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -28,6 +28,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Menu, Provider } from "react-native-paper";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useFocusEffect } from "@react-navigation/native";
+import { useOwnerId } from "../../hooks/useOwnerId";
 import AudioRecord from "react-native-audio-record";
 import Sound from "react-native-sound";
 
@@ -66,6 +67,7 @@ function base64ToArrayBuffer(b64: string): ArrayBuffer {
 }
 
 export default function Chat() {
+  const ownerId = useOwnerId();
   // 時間計測
   const [msg, setMsg] = useState("");
   const [log, setLog] = useState<string[]>([]);
@@ -185,7 +187,7 @@ export default function Chat() {
 
   const fetchSessions = async () => {
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/logs/sessions?owner_id=user_123&device_id=app`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/logs/sessions?owner_id=${encodeURIComponent(ownerId!)}&device_id=app`);
       const data = await res.json();
       setSessions(data.sessions ?? []);
     } catch {}
@@ -203,7 +205,7 @@ export default function Chat() {
   const loadSession = async (sid: string) => {
     closeDrawer();
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/logs/messages?owner_id=user_123&device_id=app&session_id=${sid}`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/logs/messages?owner_id=${encodeURIComponent(ownerId!)}&device_id=app&session_id=${sid}`);
       const data = await res.json();
       const messages: any[] = data.messages ?? [];
       const newLog: string[] = [];
@@ -1002,7 +1004,7 @@ export default function Chat() {
         character_id: selectedCharacterRef.current.character_id,
         messages: [...historyMessages, { role: "user", content: t }],
         session_id: sessionIdRef.current,
-        owner_id: "user_123",
+        owner_id: ownerId,
         device_id: "app",
         request_at: new Date().toISOString(),
       };

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useOwnerId } from "../../hooks/useOwnerId";
 import {
   SafeAreaView,
   Text,
@@ -60,6 +61,7 @@ type LogMessage = {
 };
 
 export default function Toy() {
+  const ownerId = useOwnerId();
   const [status, setStatus]                         = useState<ConnectionStatus>("disconnected");
   const [bleDevices, setBleDevices]                 = useState<Device[]>([]);
   const [connectedDevice, setConnectedDevice]       = useState<Device | null>(null);
@@ -204,7 +206,7 @@ export default function Toy() {
       const res = await fetch(`${DEVICE_SETTING_URL}/devices`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ device_id: mac }),
+        body: JSON.stringify({ device_id: mac, owner_id: ownerId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
@@ -302,7 +304,7 @@ export default function Toy() {
     setSessionsLoading(true);
     setScreen("conversation-log");
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/logs/sessions?owner_id=${encodeURIComponent(deviceId)}&device_id=${encodeURIComponent(deviceId)}`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/logs/sessions?owner_id=${encodeURIComponent(ownerId!)}&device_id=${encodeURIComponent(deviceId)}`);
       const data = await res.json();
       setSessions(data.sessions ?? []);
     } catch (e: any) {
@@ -318,7 +320,7 @@ export default function Toy() {
     setSelectedSessionId(sessionId);
     setScreen("conversation-messages");
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/logs/messages?owner_id=${encodeURIComponent(deviceId)}&device_id=${encodeURIComponent(deviceId)}&session_id=${encodeURIComponent(sessionId)}`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/logs/messages?owner_id=${encodeURIComponent(ownerId!)}&device_id=${encodeURIComponent(deviceId)}&session_id=${encodeURIComponent(sessionId)}`);
       const data = await res.json();
       setLogMessages(data.messages ?? []);
     } catch (e: any) {

--- a/app/hooks/useOwnerId.ts
+++ b/app/hooks/useOwnerId.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const OWNER_ID_KEY = "owner_id";
+
+function generateUUID(): string {
+  const hex = "0123456789abcdef";
+  let uuid = "";
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) {
+      uuid += "-";
+    } else if (i === 14) {
+      uuid += "4";
+    } else {
+      uuid += hex[Math.floor(Math.random() * 16)];
+    }
+  }
+  return `u_${uuid}`;
+}
+
+export function useOwnerId(): string | null {
+  const [ownerId, setOwnerId] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      let id = await AsyncStorage.getItem(OWNER_ID_KEY);
+      if (!id) {
+        id = generateUUID();
+        await AsyncStorage.setItem(OWNER_ID_KEY, id);
+      }
+      setOwnerId(id);
+    })();
+  }, []);
+
+  return ownerId;
+}

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -338,6 +338,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         provider: voiceRes.Item.provider,
         vendorId: voiceRes.Item.vendor_id,
         personalityPrompt,
+        ownerId: device.owner_id ?? null,
       };
     } catch (e) {
       console.error("[DynamoDB] resolveCharacterFromDynamo error:", e);
@@ -354,7 +355,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
 
     // ---- ログ用メタデータ ----
     const sessionId  = typeof body.session_id === "string" ? body.session_id : "unknown";
-    const ownerId    = typeof body.owner_id   === "string" ? body.owner_id   : deviceId ?? "unknown";
+    let   ownerId    = typeof body.owner_id   === "string" ? body.owner_id   : deviceId ?? "unknown";
     const requestAt  = Date.now();
     const userTimestamp = new Date(requestAt).toISOString();
 
@@ -380,7 +381,8 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         modelKey = normalizeModelKey(charConfig.provider) ?? modelKey;
         voice    = charConfig.vendorId ?? voice;
         personalityPrompt = charConfig.personalityPrompt;
-        console.log(`[DynamoDB] device=${deviceId}, provider=${charConfig.provider}, vendorId=${charConfig.vendorId}, hasPersonality=${!!personalityPrompt}`);
+        if (charConfig.ownerId) ownerId = charConfig.ownerId;
+        console.log(`[DynamoDB] device=${deviceId}, provider=${charConfig.provider}, vendorId=${charConfig.vendorId}, hasPersonality=${!!personalityPrompt}, ownerId=${ownerId}`);
       } else {
         console.log(`[DynamoDB] device=${deviceId} not found or no character set, using defaults`);
       }

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -132,12 +132,12 @@ export const handler = async (event) => {
         ConditionExpression: "attribute_not_exists(device_id)",
       })).catch(async (err) => {
         if (err.name === "ConditionalCheckFailedException") {
-          // 登録済みなら last_seen だけ更新
+          // 登録済みなら last_seen と owner_id を更新
           await ddb.send(new UpdateCommand({
             TableName: DEVICES_TABLE,
             Key: { device_id },
-            UpdateExpression: "SET last_seen = :t",
-            ExpressionAttributeValues: { ":t": now },
+            UpdateExpression: "SET last_seen = :t, owner_id = :o",
+            ExpressionAttributeValues: { ":t": now, ":o": owner_id },
           }));
         } else {
           throw err;


### PR DESCRIPTION
## Summary
- Add `useOwnerId` hook that generates and persists a UUID per app install via AsyncStorage
- Update chat.tsx and toy.tsx to use dynamic owner_id instead of hardcoded "user_123"
- ESP32 Lambda now resolves owner_id from devices table (not from ESP32 payload) for log saving
- Device-setting Lambda updates owner_id on device re-registration

## Purpose
When a device is given to another person, the new owner won't see the previous owner's conversation logs.

## Test plan
- [ ] Fresh app install generates new UUID and stores it
- [ ] Chat logs are saved with the new UUID owner_id
- [ ] ESP32 device logs use owner_id from devices table
- [ ] Existing sessions show correctly for the current owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)