### PR TITLE
Use UUID-based owner_id for character operations

### DIFF
--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -161,14 +161,15 @@ export default function Chat() {
 
   useFocusEffect(
     useCallback(() => {
+      if (!ownerId) return;
       (async () => {
         try {
-          const res = await fetch(`${DEVICE_SETTING_URL}/characters`);
+          const res = await fetch(`${DEVICE_SETTING_URL}/characters?owner_id=${encodeURIComponent(ownerId)}`);
           const data = await res.json();
           setCharacters(data.characters ?? []);
         } catch {}
       })();
-    }, [])
+    }, [ownerId])
   );
 
   // ドロワー操作

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -15,6 +15,7 @@ import {
 } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useRef, useState } from "react";
+import { useOwnerId } from "../../hooks/useOwnerId";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
@@ -48,6 +49,7 @@ const PERSONALITY_TEMPLATES = [
 ];
 
 export default function Settings() {
+  const ownerId = useOwnerId();
   const [screen, setScreen] = useState<SettingsScreen>("main");
   const slideAnim = useRef(new Animated.Value(0)).current;
 
@@ -98,9 +100,10 @@ export default function Settings() {
 
   // ---- キャラクター一覧 ----
   const loadCharacters = async () => {
+    if (!ownerId) return;
     setCharsLoading(true);
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/characters`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/characters?owner_id=${encodeURIComponent(ownerId)}`);
       const data = await res.json();
       setCharacters(data.characters ?? []);
     } catch {
@@ -187,7 +190,7 @@ export default function Settings() {
         const res = await fetch(`${DEVICE_SETTING_URL}/characters`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId }),
+          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId, owner_id: ownerId }),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
       }


### PR DESCRIPTION
## Summary
- settings.tsx / chat.tsx でキャラクター取得・作成時に実際の owner_id を渡すように修正
- owner_id 未確定時のフェッチをスキップし、user_123 へのフォールバックを防止
- これにより各ユーザーが自分のキャラクターのみ表示・作成できるようになる

## Test plan
- [ ] アプリでキャラクター一覧を開き、自分が作成したキャラクターのみ表示されることを確認
- [ ] 新規キャラクター作成後、DynamoDB上のowner_idがUUID形式であることを確認
- [ ] チャット画面のキャラクター選択で他ユーザーのキャラクターが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)