### PR TITLE
Add multi-device management and fix shared ID issue

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "ToyTalk",
     "slug": "toytalk",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "toytalk",
@@ -10,7 +10,7 @@
     "newArchEnabled": true,
     "ios": {
       "bundleIdentifier": "com.zakicorp.toytalk",
-      "buildNumber": "16",
+      "buildNumber": "17",
       "supportsTablet": false,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -216,6 +216,7 @@ export default function Settings() {
         </View>
         <ScrollView contentContainerStyle={s.wrap}>
           {[
+            { ver: "0.7.1", date: "20260328", desc: "複数デバイスの登録機能、他のユーザーの会話が見えてしまう問題を修正" },
             { ver: "0.7.0", date: "20260322", desc: "キャラクターシステム追加、会話ログ機能追加、UI刷新" },
             { ver: "0.6.0", date: "20260306", desc: "ボイス追加：ElevenLabs / Fish Audio（※デモ用）" },
             { ver: "0.5.6", date: "20260210", desc: "おもちゃにWIFI設定機能追加" },

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -46,6 +46,7 @@ type RegisteredDevice = {
   device_id: string;
   character_id: string | null;
   owner_id: string;
+  device_name: string;
 };
 
 type SessionItem = {
@@ -69,10 +70,10 @@ export default function Toy() {
   const [password, setPassword]                     = useState("");
   const [statusMessage, setStatusMessage]           = useState("");
   const [screen, setScreen]                         = useState<Screen>("home");
-  const [deviceId, setDeviceId]                     = useState<string | null>(null);
-  const [registeredDevice, setRegisteredDevice]     = useState<RegisteredDevice | null>(null);
-  const [characters, setCharacters]                 = useState<CharacterItem[]>([]);
-  const [charactersLoading, setCharactersLoading]   = useState(false);
+  const [deviceId, setDeviceId]                       = useState<string | null>(null);
+  const [registeredDevices, setRegisteredDevices]     = useState<RegisteredDevice[]>([]);
+  const [characters, setCharacters]                   = useState<CharacterItem[]>([]);
+  const [charactersLoading, setCharactersLoading]     = useState(false);
   const [updatingCharacter, setUpdatingCharacter]   = useState(false);
   const [sessions, setSessions]                     = useState<SessionItem[]>([]);
   const [sessionsLoading, setSessionsLoading]       = useState(false);
@@ -84,18 +85,97 @@ export default function Toy() {
     if (Platform.OS === "android") {
       requestAndroidPermissions();
     }
-    // AsyncStorageから登録済みデバイスを復元
-    AsyncStorage.getItem("registeredDevice").then((val) => {
-      if (val) {
-        const d = JSON.parse(val);
-        setRegisteredDevice(d);
-        setDeviceId(d.device_id);
+    // AsyncStorageから登録済みデバイスを復元（旧キーからのマイグレーション対応）
+    (async () => {
+      const newVal = await AsyncStorage.getItem("registeredDevices");
+      if (newVal) {
+        setRegisteredDevices(JSON.parse(newVal));
+      } else {
+        const oldVal = await AsyncStorage.getItem("registeredDevice");
+        if (oldVal) {
+          const d = JSON.parse(oldVal);
+          const migrated = [{ ...d, device_name: d.device_name ?? "" }];
+          setRegisteredDevices(migrated);
+          await AsyncStorage.setItem("registeredDevices", JSON.stringify(migrated));
+          await AsyncStorage.removeItem("registeredDevice");
+        }
       }
-    });
+    })();
     return () => {
       bleManager.stopDeviceScan();
     };
   }, []);
+
+  // サーバーからデバイス一覧を同期
+  useEffect(() => {
+    if (!ownerId) return;
+    (async () => {
+      try {
+        const res = await fetch(`${DEVICE_SETTING_URL}/devices?owner_id=${encodeURIComponent(ownerId)}`);
+        const data = await res.json();
+        if (data.devices?.length > 0) {
+          const devices = data.devices.map((d: any) => ({
+            device_id: d.device_id,
+            character_id: d.character_id,
+            owner_id: d.owner_id,
+            device_name: d.device_name ?? "",
+          }));
+          setRegisteredDevices(devices);
+          await AsyncStorage.setItem("registeredDevices", JSON.stringify(devices));
+        }
+      } catch {}
+    })();
+  }, [ownerId]);
+
+  // キャラクター一覧をプリフェッチ（名前表示用）
+  useEffect(() => {
+    if (!ownerId) return;
+    (async () => {
+      try {
+        const res = await fetch(`${DEVICE_SETTING_URL}/characters?owner_id=${encodeURIComponent(ownerId)}`);
+        const data = await res.json();
+        setCharacters(data.characters ?? []);
+      } catch {}
+    })();
+  }, [ownerId]);
+
+  const currentDevice = registeredDevices.find((d) => d.device_id === deviceId) ?? null;
+
+  const addOrUpdateDevice = async (device: RegisteredDevice) => {
+    setRegisteredDevices((prev) => {
+      const idx = prev.findIndex((d) => d.device_id === device.device_id);
+      const updated = idx >= 0
+        ? prev.map((d, i) => (i === idx ? { ...device, device_name: device.device_name || d.device_name } : d))
+        : [...prev, device];
+      AsyncStorage.setItem("registeredDevices", JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const removeDevice = async (targetDeviceId: string) => {
+    setRegisteredDevices((prev) => {
+      const updated = prev.filter((d) => d.device_id !== targetDeviceId);
+      AsyncStorage.setItem("registeredDevices", JSON.stringify(updated));
+      return updated;
+    });
+    setDeviceId(null);
+    setScreen("home");
+  };
+
+  const updateDeviceName = async (targetDeviceId: string, name: string) => {
+    setRegisteredDevices((prev) => {
+      const updated = prev.map((d) => (d.device_id === targetDeviceId ? { ...d, device_name: name } : d));
+      AsyncStorage.setItem("registeredDevices", JSON.stringify(updated));
+      return updated;
+    });
+    try {
+      await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(targetDeviceId)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ device_name: name }),
+      });
+    } catch {}
+  };
 
   const requestAndroidPermissions = async () => {
     if (Platform.OS === "android" && Platform.Version >= 31) {
@@ -213,8 +293,7 @@ export default function Toy() {
       // 登録後にデバイス情報を取得
       const deviceRes = await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(mac)}`);
       const deviceData = await deviceRes.json();
-      setRegisteredDevice(deviceData);
-      await AsyncStorage.setItem("registeredDevice", JSON.stringify(deviceData));
+      await addOrUpdateDevice({ ...deviceData, device_name: deviceData.device_name ?? "" });
       setStatusMessage("デバイス登録完了！");
     } catch (e: any) {
       setStatusMessage("デバイス登録エラー: " + e.message);
@@ -266,7 +345,7 @@ export default function Toy() {
     setCharactersLoading(true);
     setScreen("character-select");
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/characters`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/characters?owner_id=${encodeURIComponent(ownerId!)}`);
       const data = await res.json();
       setCharacters(data.characters ?? []);
     } catch (e: any) {
@@ -286,9 +365,9 @@ export default function Toy() {
         body: JSON.stringify({ character_id: characterId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setRegisteredDevice((prev) => {
-        const updated = prev ? { ...prev, character_id: characterId } : prev;
-        if (updated) AsyncStorage.setItem("registeredDevice", JSON.stringify(updated));
+      setRegisteredDevices((prev) => {
+        const updated = prev.map((d) => (d.device_id === deviceId ? { ...d, character_id: characterId } : d));
+        AsyncStorage.setItem("registeredDevices", JSON.stringify(updated));
         return updated;
       });
       setScreen("device-settings");
@@ -330,10 +409,11 @@ export default function Toy() {
     }
   };
 
-  const currentCharacterLabel = () => {
-    if (!registeredDevice?.character_id || registeredDevice.character_id === "default") return "デフォルト";
-    const c = characters.find((c) => c.character_id === registeredDevice.character_id);
-    return c ? c.name : registeredDevice.character_id;
+  const currentCharacterLabel = (device?: RegisteredDevice | null) => {
+    const d = device ?? currentDevice;
+    if (!d?.character_id || d.character_id === "default") return "デフォルト";
+    const c = characters.find((c) => c.character_id === d.character_id);
+    return c ? c.name : d.character_id;
   };
 
   // ---- 会話メッセージ画面 ----
@@ -415,7 +495,7 @@ export default function Toy() {
 
   // ---- キャラクター選択画面 ----
   if (screen === "character-select") {
-    const currentId = registeredDevice?.character_id ?? DEFAULT_CHARACTER_ID;
+    const currentId = currentDevice?.character_id ?? DEFAULT_CHARACTER_ID;
     const systemChars = characters.filter((c) => c.owner_id === "system");
     const userChars   = characters.filter((c) => c.owner_id !== "system");
 
@@ -479,6 +559,26 @@ export default function Toy() {
 
   // ---- デバイス設定画面 ----
   if (screen === "device-settings") {
+    const deleteDevice = () => {
+      Alert.alert("デバイスを削除", "このデバイスの登録を解除しますか？", [
+        { text: "キャンセル", style: "cancel" },
+        {
+          text: "削除",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(deviceId!)}`, {
+                method: "DELETE",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ owner_id: ownerId }),
+              });
+            } catch {}
+            await removeDevice(deviceId!);
+          },
+        },
+      ]);
+    };
+
     return (
       <SafeAreaView style={s.root}>
         <View style={s.header}>
@@ -487,7 +587,21 @@ export default function Toy() {
           </TouchableOpacity>
           <Text style={s.headerTitle}>デバイス設定</Text>
         </View>
-        <View style={s.wrap}>
+        <ScrollView contentContainerStyle={s.wrap}>
+          <TextInput
+            style={s.input}
+            value={currentDevice?.device_name ?? ""}
+            onChangeText={(text) => {
+              setRegisteredDevices((prev) =>
+                prev.map((d) => (d.device_id === deviceId ? { ...d, device_name: text } : d))
+              );
+            }}
+            onEndEditing={(e) => {
+              if (deviceId) updateDeviceName(deviceId, e.nativeEvent.text);
+            }}
+            placeholder={deviceId ?? "デバイス名を入力"}
+            autoCapitalize="none"
+          />
           <Text style={s.deviceIdText}>{deviceId}</Text>
           <TouchableOpacity style={s.settingRow} onPress={openCharacterSelect}>
             <View>
@@ -503,7 +617,10 @@ export default function Toy() {
             </View>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
-        </View>
+          <TouchableOpacity style={s.deleteButton} onPress={deleteDevice}>
+            <Text style={s.deleteButtonText}>デバイスを削除</Text>
+          </TouchableOpacity>
+        </ScrollView>
       </SafeAreaView>
     );
   }
@@ -630,18 +747,27 @@ export default function Toy() {
         )}
 
         {/* 登録済みデバイス（常に最下部に表示） */}
-        {registeredDevice && (
+        {registeredDevices.length > 0 && (
           <View style={s.section}>
             <Text style={s.subtitle}>登録済みデバイス</Text>
-            <TouchableOpacity style={s.deviceItem} onPress={openDeviceSettings}>
-              <View>
-                <Text style={s.deviceName}>{registeredDevice.device_id}</Text>
-                <Text style={s.deviceSub}>
-                  キャラクター: {registeredDevice.character_id ?? "未設定"}
-                </Text>
-              </View>
-              <Text style={s.chevron}>›</Text>
-            </TouchableOpacity>
+            {registeredDevices.map((device) => (
+              <TouchableOpacity
+                key={device.device_id}
+                style={s.deviceItem}
+                onPress={() => {
+                  setDeviceId(device.device_id);
+                  openDeviceSettings();
+                }}
+              >
+                <View>
+                  <Text style={s.deviceName}>{device.device_name || device.device_id}</Text>
+                  <Text style={s.deviceSub}>
+                    キャラクター: {currentCharacterLabel(device)}
+                  </Text>
+                </View>
+                <Text style={s.chevron}>›</Text>
+              </TouchableOpacity>
+            ))}
           </View>
         )}
       </ScrollView>
@@ -690,6 +816,9 @@ const s = StyleSheet.create({
   characterLabelSelected:{ color: "#007AFF", fontWeight: "600" },
   characterDesc:         { fontSize: 12, color: "#888", marginTop: 2 },
   sectionHeader:         { fontSize: 13, fontWeight: "700", color: "#555", marginTop: 12, marginBottom: 6, textTransform: "uppercase" },
+  // 削除ボタン
+  deleteButton:          { marginTop: 24, padding: 16, borderRadius: 12, borderWidth: 1, borderColor: "#ff3b30", alignItems: "center" as const },
+  deleteButtonText:      { color: "#ff3b30", fontSize: 16, fontWeight: "600" as const },
   // 会話ログ
   emptyText:             { fontSize: 14, color: "#999" },
   msgBubble:             { padding: 12, borderRadius: 12, maxWidth: "85%" },

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -125,6 +125,7 @@ export const handler = async (event) => {
           device_id,
           owner_id,
           character_id: "default",
+          device_name: "",
           created_at: now,
           last_seen: now,
         },
@@ -147,6 +148,41 @@ export const handler = async (event) => {
       return response(200, { device_id, message: "Device registered" });
     }
 
+    // ---- GET /devices ---- デバイス一覧取得（owner_id でフィルタ）
+    if (method === "GET" && path === "/devices") {
+      const owner_id = event.queryStringParameters?.owner_id;
+      if (!owner_id) return response(400, { error: "owner_id is required" });
+
+      const result = await ddb.send(new ScanCommand({
+        TableName: DEVICES_TABLE,
+        FilterExpression: "owner_id = :o",
+        ExpressionAttributeValues: { ":o": owner_id },
+      }));
+      return response(200, { devices: result.Items ?? [] });
+    }
+
+    // ---- DELETE /devices/{device_id} ---- デバイス削除
+    if (method === "DELETE" && path.startsWith("/devices/")) {
+      const device_id = decodeURIComponent(path.split("/")[2]);
+      const body = JSON.parse(event.body ?? "{}");
+      const { owner_id } = body;
+
+      const existing = await ddb.send(new GetCommand({
+        TableName: DEVICES_TABLE,
+        Key: { device_id },
+      }));
+      if (!existing.Item) return response(404, { error: "Device not found" });
+      if (owner_id && existing.Item.owner_id !== owner_id) {
+        return response(403, { error: "Not authorized to delete this device" });
+      }
+
+      await ddb.send(new DeleteCommand({
+        TableName: DEVICES_TABLE,
+        Key: { device_id },
+      }));
+      return response(200, { message: "Device deleted" });
+    }
+
     // ---- GET /devices/{device_id} ---- デバイス取得
     if (method === "GET" && path.startsWith("/devices/")) {
       const device_id = decodeURIComponent(path.split("/")[2]);
@@ -158,23 +194,27 @@ export const handler = async (event) => {
       return response(200, result.Item);
     }
 
-    // ---- PUT /devices/{device_id} ---- キャラクター設定更新
+    // ---- PUT /devices/{device_id} ---- デバイス設定更新（character_id / device_name）
     if (method === "PUT" && path.startsWith("/devices/")) {
       const device_id = decodeURIComponent(path.split("/")[2]);
       const body      = JSON.parse(event.body ?? "{}");
-      const { character_id } = body;
-      if (!character_id) return response(400, { error: "character_id is required" });
+      const { character_id, device_name } = body;
+
+      const updates = ["last_seen = :t"];
+      const vals = { ":t": new Date().toISOString() };
+      if (character_id !== undefined) { updates.push("character_id = :c"); vals[":c"] = character_id; }
+      if (device_name  !== undefined) { updates.push("device_name = :n");  vals[":n"] = device_name; }
+      if (character_id === undefined && device_name === undefined) {
+        return response(400, { error: "character_id or device_name is required" });
+      }
 
       await ddb.send(new UpdateCommand({
         TableName: DEVICES_TABLE,
         Key: { device_id },
-        UpdateExpression: "SET character_id = :c, last_seen = :t",
-        ExpressionAttributeValues: {
-          ":c": character_id,
-          ":t": new Date().toISOString(),
-        },
+        UpdateExpression: "SET " + updates.join(", "),
+        ExpressionAttributeValues: vals,
       }));
-      return response(200, { device_id, character_id, message: "Device updated" });
+      return response(200, { device_id, message: "Device updated" });
     }
 
     // ---- GET /logs/sessions ---- セッション一覧取得


### PR DESCRIPTION
## Summary
- 複数デバイスの登録・管理機能を追加（名前付け、削除、サーバー同期）
- 他のユーザーの会話が見えてしまう問題を修正（owner_id ベースのフィルタリング）
- バージョン 0.7.1 (build 17) に更新

## Changes
- **Frontend**: `registeredDevice` (単体) → `registeredDevices` (配列) に移行、デバイス名編集・削除UI追加
- **Backend**: `GET /devices?owner_id=`, `DELETE /devices/{device_id}` エンドポイント追加、`PUT` で `device_name` 更新対応

## Test plan
- [ ] 既存デバイスが旧 AsyncStorage キーから正しくマイグレーションされること
- [ ] 複数デバイスの登録・表示・削除が動作すること
- [ ] デバイス名の編集がサーバーに同期されること
- [ ] 他ユーザーの会話ログが見えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)