### PR TITLE
Add pluggable LLM providers (GPT-4.1 mini / Gemini 2.5 Flash / Claude Haiku 4.5)

### DIFF
--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -237,8 +237,8 @@ export default function Settings() {
       <SafeAreaView style={s.root}>
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
         <View style={s.header}>
-          <TouchableOpacity onPress={() => navigateTo("main", "back")}>
-            <Text style={s.back}>← 戻る</Text>
+          <TouchableOpacity onPress={() => navigateTo("main", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+            <Text style={s.back}>←</Text>
           </TouchableOpacity>
           <Text style={s.headerTitle}>バージョン情報</Text>
         </View>
@@ -289,8 +289,8 @@ export default function Settings() {
       <SafeAreaView style={s.root}>
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
         <View style={s.header}>
-          <TouchableOpacity onPress={() => navigateTo("main", "back")}>
-            <Text style={s.back}>← 戻る</Text>
+          <TouchableOpacity onPress={() => navigateTo("main", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+            <Text style={s.back}>←</Text>
           </TouchableOpacity>
           <Text style={s.headerTitle}>音声認識</Text>
         </View>
@@ -340,8 +340,8 @@ export default function Settings() {
       <SafeAreaView style={s.root}>
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
           <View style={s.header}>
-            <TouchableOpacity onPress={() => navigateTo("character-edit", "back")}>
-              <Text style={s.back}>← ��る</Text>
+            <TouchableOpacity onPress={() => navigateTo("character-edit", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+              <Text style={s.back}>←</Text>
             </TouchableOpacity>
             <Text style={s.headerTitle}>LLM選択</Text>
           </View>
@@ -380,8 +380,8 @@ export default function Settings() {
       <SafeAreaView style={s.root}>
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
           <View style={s.header}>
-            <TouchableOpacity onPress={() => navigateTo("character-edit", "back")}>
-              <Text style={s.back}>← 戻る</Text>
+            <TouchableOpacity onPress={() => navigateTo("character-edit", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+              <Text style={s.back}>←</Text>
             </TouchableOpacity>
             <Text style={s.headerTitle}>ボイス選択</Text>
           </View>
@@ -418,8 +418,8 @@ export default function Settings() {
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
         <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === "ios" ? "padding" : "height"}>
         <View style={s.header}>
-          <TouchableOpacity onPress={() => navigateTo("character-list", "back")}>
-            <Text style={s.back}>← 戻る</Text>
+          <TouchableOpacity onPress={() => navigateTo("character-list", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+            <Text style={s.back}>←</Text>
           </TouchableOpacity>
           <Text style={s.headerTitle}>{editingCharacter ? "キャラクター編集" : "キャラクター作成"}</Text>
         </View>
@@ -500,8 +500,8 @@ export default function Settings() {
       <SafeAreaView style={s.root}>
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
         <View style={s.header}>
-          <TouchableOpacity onPress={() => navigateTo("main", "back")}>
-            <Text style={s.back}>← 戻る</Text>
+          <TouchableOpacity onPress={() => navigateTo("main", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+            <Text style={s.back}>←</Text>
           </TouchableOpacity>
           <Text style={s.headerTitle}>キャラクター管理</Text>
         </View>

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -19,7 +19,7 @@ import { useOwnerId } from "../../hooks/useOwnerId";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
-type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "version";
+type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "llm-select" | "version";
 
 type CharacterItem = {
   character_id: string;
@@ -27,6 +27,7 @@ type CharacterItem = {
   description: string;
   owner_id: string;
   voice_id: string;
+  llm_id?: string;
   personality_prompt?: string;
 };
 
@@ -35,6 +36,13 @@ type VoiceItem = {
   label: string;
   provider: string;
   vendor_id: string;
+};
+
+type LlmItem = {
+  llm_id: string;
+  label: string;
+  provider: string;
+  model_id: string;
 };
 
 const DEVICE_SETTING_URL = "https://7k6nkpy3tf2drljy77pnouohjm0buoux.lambda-url.ap-northeast-1.on.aws";
@@ -78,12 +86,17 @@ export default function Settings() {
   const [charDesc, setCharDesc] = useState("");
   const [charPrompt, setCharPrompt] = useState("");
   const [charVoiceId, setCharVoiceId] = useState("elevenlabs_sameno");
+  const [charLlmId, setCharLlmId] = useState("openai_gpt41mini");
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   // ボイス一覧
   const [voices, setVoices] = useState<VoiceItem[]>([]);
   const [voicesLoading, setVoicesLoading] = useState(false);
+
+  // LLM一覧
+  const [llms, setLlms] = useState<LlmItem[]>([]);
+  const [llmsLoading, setLlmsLoading] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -126,6 +139,19 @@ export default function Settings() {
     }
   };
 
+  const loadLlms = async () => {
+    setLlmsLoading(true);
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/llms`);
+      const data = await res.json();
+      setLlms(data.llms ?? []);
+    } catch {
+      Alert.alert("エラー", "LLM一覧の取得に失敗しました");
+    } finally {
+      setLlmsLoading(false);
+    }
+  };
+
   const openCharacterList = () => {
     navigateTo("character-list");
     loadCharacters();
@@ -137,9 +163,11 @@ export default function Settings() {
     setCharDesc(character?.description ?? "");
     setCharPrompt(character?.personality_prompt ?? "");
     setCharVoiceId(character?.voice_id ?? "elevenlabs_sameno");
+    setCharLlmId(character?.llm_id ?? "openai_gpt41mini");
     setSelectedTemplate(null);
     navigateTo("character-edit");
     loadVoices();
+    loadLlms();
   };
 
   const deleteCharacter = async (characterId: string) => {
@@ -182,7 +210,7 @@ export default function Settings() {
         const res = await fetch(`${DEVICE_SETTING_URL}/characters/${encodeURIComponent(editingCharacter.character_id)}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId }),
+          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId, llm_id: charLlmId }),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
       } else {
@@ -190,7 +218,7 @@ export default function Settings() {
         const res = await fetch(`${DEVICE_SETTING_URL}/characters`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId, owner_id: ownerId }),
+          body: JSON.stringify({ name: charName.trim(), description: charDesc.trim(), personality_prompt: charPrompt.trim(), voice_id: charVoiceId, llm_id: charLlmId, owner_id: ownerId }),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
       }
@@ -301,7 +329,52 @@ export default function Settings() {
     return v ? `${v.label} (${v.provider})` : charVoiceId;
   };
 
-  // ---- ボイス選択画面 ----
+  const currentLlmLabel = () => {
+    const l = llms.find((l) => l.llm_id === charLlmId);
+    return l ? l.label : charLlmId;
+  };
+
+  // ---- LLM選択画面 ----
+  if (screen === "llm-select") {
+    return (
+      <SafeAreaView style={s.root}>
+        <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
+          <View style={s.header}>
+            <TouchableOpacity onPress={() => navigateTo("character-edit", "back")}>
+              <Text style={s.back}>← ��る</Text>
+            </TouchableOpacity>
+            <Text style={s.headerTitle}>LLM選択</Text>
+          </View>
+          <ScrollView contentContainerStyle={{ padding: 16, gap: 8 }}>
+            {llmsLoading ? (
+              <ActivityIndicator size="large" color="#007AFF" style={{ marginTop: 24 }} />
+            ) : (
+              [...new Set(llms.map((l) => l.provider))].map((provider) => (
+                <View key={provider}>
+                  <Text style={s.listSectionHeader}>{provider}</Text>
+                  {llms.filter((l) => l.provider === provider).map((l) => {
+                    const selected = l.llm_id === charLlmId;
+                    return (
+                      <TouchableOpacity
+                        key={l.llm_id}
+                        style={[s.voiceRow, selected && s.voiceRowSelected]}
+                        onPress={() => { setCharLlmId(l.llm_id); navigateTo("character-edit", "back"); }}
+                      >
+                        <View style={[s.radio, selected && s.radioSelected]} />
+                        <Text style={[s.voiceLabel, selected && s.voiceLabelSelected]}>{l.label}</Text>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
+              ))
+            )}
+          </ScrollView>
+        </Animated.View>
+      </SafeAreaView>
+    );
+  }
+
+  // ---- ボイス��択画面 ----
   if (screen === "voice-select") {
     return (
       <SafeAreaView style={s.root}>
@@ -385,6 +458,12 @@ export default function Settings() {
           <Text style={[s.sectionTitle, { marginTop: 16 }]}>ボイス</Text>
           <TouchableOpacity style={s.settingRow} onPress={() => navigateTo("voice-select")}>
             <Text style={s.settingRowText}>{voicesLoading ? "読み込み中..." : currentVoiceLabel()}</Text>
+            <Text style={s.chevron}>›</Text>
+          </TouchableOpacity>
+
+          <Text style={[s.sectionTitle, { marginTop: 16 }]}>LLM</Text>
+          <TouchableOpacity style={s.settingRow} onPress={() => navigateTo("llm-select")}>
+            <Text style={s.settingRowText}>{llmsLoading ? "読み込み中..." : currentLlmLabel()}</Text>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
 

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -467,10 +467,14 @@ export default function Settings() {
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
 
+          <TouchableOpacity style={[s.button, saving && s.buttonDisabled, { marginTop: 32 }]} onPress={saveCharacter} disabled={saving}>
+            {saving ? <ActivityIndicator color="#fff" /> : <Text style={s.buttonText}>{editingCharacter ? "保存する" : "作成する"}</Text>}
+          </TouchableOpacity>
+
           {/* 削除ボタン（カスタムキャラの編集時のみ） */}
           {editingCharacter && editingCharacter.owner_id !== "system" && (
             <TouchableOpacity
-              style={[s.buttonDanger, { marginTop: 32 }, deletingId === editingCharacter.character_id && s.buttonDisabled]}
+              style={[s.buttonDanger, { marginTop: 12 }, deletingId === editingCharacter.character_id && s.buttonDisabled]}
               onPress={() => deleteCharacter(editingCharacter.character_id)}
               disabled={deletingId === editingCharacter.character_id}
             >
@@ -479,10 +483,6 @@ export default function Settings() {
                 : <Text style={s.buttonText}>削除する</Text>}
             </TouchableOpacity>
           )}
-
-          <TouchableOpacity style={[s.button, saving && s.buttonDisabled, { marginTop: 12 }]} onPress={saveCharacter} disabled={saving}>
-            {saving ? <ActivityIndicator color="#fff" /> : <Text style={s.buttonText}>{editingCharacter ? "保存する" : "作成する"}</Text>}
-          </TouchableOpacity>
         </ScrollView>
 
         </KeyboardAvoidingView>

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -453,7 +453,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
 
     // システムプロンプトを追加（キャラクターの個性 + 共通指示）
     const now = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo", year: "numeric", month: "long", day: "numeric", weekday: "short", hour: "2-digit", minute: "2-digit" });
-    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。`;
+    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。相手が話した言語で返答してください。`;
     const systemPrompt = {
       role: "system",
       content: personalityPrompt ? `${personalityPrompt}\n\n${basePrompt}` : basePrompt,

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -543,13 +543,75 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       })();
     }
 
+    function streamLLMAnthropic(msgs, model) {
+      const systemMsg = msgs.find(m => m.role === "system");
+      const chatMsgs = msgs.filter(m => m.role !== "system");
+
+      const body = {
+        model,
+        max_tokens: 1024,
+        stream: true,
+        temperature: 0.7,
+        messages: chatMsgs,
+      };
+      if (systemMsg) {
+        body.system = systemMsg.content;
+      }
+
+      const key = process.env.ANTHROPIC_API_KEY;
+
+      return (async function* () {
+        const resp = await fetch("https://api.anthropic.com/v1/messages", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+          },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+          const errText = await resp.text();
+          throw new Error(`Anthropic API error: ${resp.status} ${errText}`);
+        }
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const lines = buf.split("\n");
+          buf = lines.pop();
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            const data = line.slice(6).trim();
+            try {
+              const parsed = JSON.parse(data);
+              if (parsed.type === "content_block_delta") {
+                const text = parsed.delta?.text ?? "";
+                if (text) yield text;
+              } else if (parsed.type === "message_delta" && parsed.usage) {
+                llmTokensOut = parsed.usage.output_tokens ?? 0;
+              } else if (parsed.type === "message_start" && parsed.message?.usage) {
+                llmTokensIn = parsed.message.usage.input_tokens ?? 0;
+              } else if (parsed.type === "message_stop") {
+                return;
+              }
+            } catch {}
+          }
+        }
+      })();
+    }
+
     let llmStream;
     if (llmProvider === "openai") {
       llmStream = streamLLMOpenAI(messagesWithSystem, llmModelId);
     } else if (llmProvider === "google") {
       llmStream = streamLLMGemini(messagesWithSystem, llmModelId);
+    } else if (llmProvider === "anthropic") {
+      llmStream = streamLLMAnthropic(messagesWithSystem, llmModelId);
     } else {
-      // Anthropic は後で追加
       const fallback = "（LLM ルート未実装です）";
       llmStream = (async function* () { yield fallback; })();
     }

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -12,6 +12,7 @@
   const VOICES_TABLE     = "toytalker-voices";
   const CHARACTERS_TABLE = "toytalker-characters";
   const CHAT_LOGS_TABLE  = "toytalker-chat-logs";
+  const LLMS_TABLE       = "toytalker-llms";
 
   async function saveLog(item) {
     try {
@@ -54,47 +55,20 @@
 
   const sha1  = (s)=>createHash("sha1").update(s).digest("hex");
 
-  // ---- 選択モデル定義（まずは OpenAI 固定運用）----
-  const MODEL_DEFAULT = "OpenAI";
-  /** 将来の拡張用にテーブル化しておく（今は OpenAI だけ使う） */
-  const MODEL_TABLE = {
-    OpenAI: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "openai",
-      ttsModel:  "gpt-4o-mini-tts-2025-03-20",
-    },
-    Google: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "google",
-      ttsModel:  "google-tts",
-    },
-    Gemini: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "gemini",
-      ttsModel:  "gemini-2.5-flash-preview-tts",
-    },
-    ElevenLabs: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "elevenlabs",
-      ttsModel:  "eleven_turbo_v2_5",
-    },
-    FishAudio: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "fishaudio",
-      ttsModel:  "fishaudio",
-    },
-    Sakura: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "sakura",
-      ttsModel:  "sakura",
-    },
+  // ---- TTS設定（プロバイダーごと）----
+  const TTS_DEFAULT = "OpenAI";
+  const TTS_TABLE = {
+    OpenAI:     { ttsVendor: "openai",     ttsModel: "gpt-4o-mini-tts-2025-03-20" },
+    Google:     { ttsVendor: "google",     ttsModel: "google-tts" },
+    Gemini:     { ttsVendor: "gemini",     ttsModel: "gemini-2.5-flash-preview-tts" },
+    ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
+    FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
+    Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
   };
+
+  // ---- LLMデフォルト（llm_id未設定時のフォールバック）----
+  const LLM_DEFAULT_PROVIDER = "openai";
+  const LLM_DEFAULT_MODEL    = "gpt-4.1-mini";
 
 
 
@@ -350,8 +324,8 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
 
       let voiceId = null;
       let personalityPrompt = null;
+      let llmId = null;
 
-      // character_id があればキャラクターテーブルを参照
       if (device.character_id && device.character_id !== "default") {
         const charRes = await ddb.send(new GetCommand({
           TableName: CHARACTERS_TABLE,
@@ -360,10 +334,10 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         if (charRes.Item) {
           voiceId = charRes.Item.voice_id ?? null;
           personalityPrompt = charRes.Item.personality_prompt || null;
+          llmId = charRes.Item.llm_id ?? null;
         }
       }
 
-      // character_id が未設定またはキャラに voice_id がなければ device.voice_id にフォールバック（後方互換）
       if (!voiceId) voiceId = device.voice_id ?? null;
       if (!voiceId) return null;
 
@@ -373,11 +347,27 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       }));
       if (!voiceRes.Item) return null;
 
+      // LLM設定を解決（llm_id未設定ならデフォルト）
+      let llmProvider = LLM_DEFAULT_PROVIDER;
+      let llmModelId  = LLM_DEFAULT_MODEL;
+      if (llmId) {
+        const llmRes = await ddb.send(new GetCommand({
+          TableName: LLMS_TABLE,
+          Key: { llm_id: llmId },
+        }));
+        if (llmRes.Item) {
+          llmProvider = llmRes.Item.provider;
+          llmModelId  = llmRes.Item.model_id;
+        }
+      }
+
       return {
         provider: voiceRes.Item.provider,
         vendorId: voiceRes.Item.vendor_id,
         personalityPrompt,
         ownerId: device.owner_id ?? null,
+        llmProvider,
+        llmModelId,
       };
     } catch (e) {
       console.error("[DynamoDB] resolveCharacterFromDynamo error:", e);
@@ -411,29 +401,32 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
     }
 
     // device_idがあればDynamoDBからキャラクター＆ボイス設定を取得、なければbodyの値を使う
-    let modelKey = normalizeModelKey(body.model) ?? MODEL_DEFAULT;
+    let ttsKey = normalizeModelKey(body.model) ?? TTS_DEFAULT;
     let voice    = body.voice ?? VOICE_DEFAULT;
     let personalityPrompt = null;
+    let llmProvider = LLM_DEFAULT_PROVIDER;
+    let llmModelId  = LLM_DEFAULT_MODEL;
 
     if (deviceId) {
       const charConfig = await resolveCharacterFromDynamo(deviceId);
       if (charConfig) {
-        modelKey = normalizeModelKey(charConfig.provider) ?? modelKey;
+        ttsKey = normalizeModelKey(charConfig.provider) ?? ttsKey;
         voice    = charConfig.vendorId ?? voice;
         personalityPrompt = charConfig.personalityPrompt;
+        llmProvider = charConfig.llmProvider;
+        llmModelId  = charConfig.llmModelId;
         if (charConfig.ownerId) ownerId = charConfig.ownerId;
-        console.log(`[DynamoDB] device=${deviceId}, provider=${charConfig.provider}, vendorId=${charConfig.vendorId}, hasPersonality=${!!personalityPrompt}, ownerId=${ownerId}`);
+        console.log(`[DynamoDB] device=${deviceId}, tts=${charConfig.provider}, voice=${charConfig.vendorId}, llm=${llmProvider}/${llmModelId}, hasPersonality=${!!personalityPrompt}, ownerId=${ownerId}`);
       } else {
         console.log(`[DynamoDB] device=${deviceId} not found or no character set, using defaults`);
       }
     }
 
-    const cfg = MODEL_TABLE[modelKey] ?? MODEL_TABLE[MODEL_DEFAULT];
+    const cfg = TTS_TABLE[ttsKey] ?? TTS_TABLE[TTS_DEFAULT];
 
-
-    // クライアント側の計測・デバッグ用に「採用モデル」を通知
-    sendMeta(res, "mark", { k: "model", v: modelKey });
-    sendMeta(res, "mark", { k: "llm_vendor", v: cfg.llmVendor });
+    sendMeta(res, "mark", { k: "model", v: ttsKey });
+    sendMeta(res, "mark", { k: "llm_vendor", v: llmProvider });
+    sendMeta(res, "mark", { k: "llm_model", v: llmModelId });
     sendMeta(res, "mark", { k: "tts_vendor", v: cfg.ttsVendor });
 
     // サーバ基準時刻（クライアントがREQ_TTFBやLLM/TTSとの相対を取れる）
@@ -466,16 +459,26 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
     };
     const messagesWithSystem = [systemPrompt, ...messages];
 
-    let llmStream;
-    if (cfg.llmVendor === "openai") {
-      const llm = await openai.chat.completions.create({
-        model: cfg.llmModel,
-        temperature: 0.7,
-        stream: true,
-        stream_options: { include_usage: true },
-        messages: messagesWithSystem,
-      });
-      llmStream = (async function* () {
+    // ---- ストリーム状態 ----
+    let buf = "";
+    let textAll = "";
+    let segSeq = 0;
+    let lastSegHash = "";
+    let firstTtsMarked = false;
+    let ttsChain = Promise.resolve();
+    let llmTokensIn = 0, llmTokensOut = 0;
+    let ttsInputChars = 0;
+
+    // ---- LLM ストリーム生成 ----
+    function streamLLMOpenAI(msgs, model) {
+      return (async function* () {
+        const llm = await openai.chat.completions.create({
+          model,
+          temperature: 0.7,
+          stream: true,
+          stream_options: { include_usage: true },
+          messages: msgs,
+        });
         for await (const chunk of llm) {
           if (chunk.usage) {
             llmTokensIn  = chunk.usage.prompt_tokens     ?? 0;
@@ -485,21 +488,16 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
           if (delta) yield delta;
         }
       })();
-    } else {
-    // もし将来 Gemini LLM に切り替えるならここで実装
-    const fallback = "（LLM ルート未実装です）";
-    llmStream = (async function* () { yield fallback; })();
-  }
+    }
 
-    // ---- ストリーム状態 ----
-    let buf = "";                 // ★ここで1回だけ宣言
-    let textAll = "";
-    let segSeq = 0;
-    let lastSegHash = "";
-    let firstTtsMarked = false;
-    let ttsChain = Promise.resolve();
-    let llmTokensIn = 0, llmTokensOut = 0;
-    let ttsInputChars = 0;
+    let llmStream;
+    if (llmProvider === "openai") {
+      llmStream = streamLLMOpenAI(messagesWithSystem, llmModelId);
+    } else {
+      // Gemini / Anthropic は後で追加
+      const fallback = "（LLM ルート未実装です）";
+      llmStream = (async function* () { yield fallback; })();
+    }
 
 
     // segment を送る唯一の経路
@@ -586,7 +584,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
           owner_id: ownerId, device_id: deviceId, source: "esp",
           role: "assistant", content: textAll.trim(),
           content_type: "text", timestamp: assistantTimestamp, session_id: sessionId,
-          llm_provider: cfg.llmVendor, llm_model: cfg.llmModel,
+          llm_provider: llmProvider, llm_model: llmModelId,
           llm_tokens_in: llmTokensIn, llm_tokens_out: llmTokensOut,
           tts_provider: cfg.ttsVendor, tts_input_units: ttsInputChars, tts_input_unit_type: "characters",
           stt_provider: "soniox", stt_input_units: null, stt_input_unit_type: null,

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -620,7 +620,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
 
     // segment を送る唯一の経路
     async function emitSegment(text, { final=false } = {}) {
-      const t = String(text ?? "").trim();
+      const t = String(text ?? "").trim().replace(/(?<=[\u3000-\u9fff])\s+(?=[\u3000-\u9fff])/g, "");
       if (!t) return;
       const h = sha1(t);
       if (h === lastSegHash) return;     // 同一文は再送しない
@@ -679,7 +679,14 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         textAll += delta;
         buf     += delta;
         if (DEBUG) sendMeta(res, "llm_token", { token: delta });
-        if (endsWithSentence(buf) || buf.trim().length >= SEG_MAX_CHARS) {
+        // buf内に文末があれば即分割してTTSに送る
+        let match;
+        while ((match = buf.match(/^(.*?[。！？!?])\s*/s))) {
+          const segText = match[1].trim();
+          buf = buf.slice(match[0].length);
+          if (segText) await emitSegment(segText);
+        }
+        if (buf.trim().length >= SEG_MAX_CHARS) {
           const segText = buf.trim();
           buf = "";
           await emitSegment(segText);

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -452,7 +452,8 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
     }
 
     // システムプロンプトを追加（キャラクターの個性 + 共通指示）
-    const basePrompt = "あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。";
+    const now = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo", year: "numeric", month: "long", day: "numeric", weekday: "short", hour: "2-digit", minute: "2-digit" });
+    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。`;
     const systemPrompt = {
       role: "system",
       content: personalityPrompt ? `${personalityPrompt}\n\n${basePrompt}` : basePrompt,

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -490,11 +490,66 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       })();
     }
 
+    function streamLLMGemini(msgs, model) {
+      const systemMsg = msgs.find(m => m.role === "system");
+      const chatMsgs = msgs.filter(m => m.role !== "system");
+      const contents = chatMsgs.map(m => ({
+        role: m.role === "assistant" ? "model" : m.role,
+        parts: [{ text: m.content }],
+      }));
+      const body = { contents };
+      if (systemMsg) {
+        body.systemInstruction = { parts: [{ text: systemMsg.content }] };
+      }
+      body.generationConfig = { temperature: 0.7 };
+
+      const key = process.env.GOOGLE_API_KEY;
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${key}`;
+
+      return (async function* () {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+          const errText = await resp.text();
+          throw new Error(`Gemini API error: ${resp.status} ${errText}`);
+        }
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const lines = buf.split("\n");
+          buf = lines.pop();
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            const data = line.slice(6).trim();
+            if (data === "[DONE]") return;
+            try {
+              const parsed = JSON.parse(data);
+              const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+              if (parsed.usageMetadata) {
+                llmTokensIn  = parsed.usageMetadata.promptTokenCount ?? 0;
+                llmTokensOut = parsed.usageMetadata.candidatesTokenCount ?? 0;
+              }
+              if (text) yield text;
+            } catch {}
+          }
+        }
+      })();
+    }
+
     let llmStream;
     if (llmProvider === "openai") {
       llmStream = streamLLMOpenAI(messagesWithSystem, llmModelId);
+    } else if (llmProvider === "google") {
+      llmStream = streamLLMGemini(messagesWithSystem, llmModelId);
     } else {
-      // Gemini / Anthropic は後で追加
+      // Anthropic は後で追加
       const fallback = "（LLM ルート未実装です）";
       llmStream = (async function* () { yield fallback; })();
     }

--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -633,7 +633,7 @@
 
     // segment を送る唯一の経路
     async function emitSegment(text, { final=false } = {}) {
-      const t = String(text ?? "").trim();
+      const t = String(text ?? "").trim().replace(/(?<=[\u3000-\u9fff])\s+(?=[\u3000-\u9fff])/g, "");
       if (!t) return;
       const h = sha1(t);
       if (h === lastSegHash) return;     // 同一文は再送しない
@@ -698,7 +698,13 @@
         textAll += delta;
         buf     += delta;
         if (DEBUG) send(res, "llm_token", { token: delta });
-        if (endsWithSentence(buf) || buf.trim().length >= SEG_MAX_CHARS) {
+        let match;
+        while ((match = buf.match(/^(.*?[。！？!?])\s*/s))) {
+          const segText = match[1].trim();
+          buf = buf.slice(match[0].length);
+          if (segText) await emitSegment(segText);
+        }
+        if (buf.trim().length >= SEG_MAX_CHARS) {
           const segText = buf.trim();
           buf = "";
           await emitSegment(segText);

--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -11,6 +11,7 @@
   const CHARACTERS_TABLE = "toytalker-characters";
   const VOICES_TABLE     = "toytalker-voices";
   const CHAT_LOGS_TABLE  = "toytalker-chat-logs";
+  const LLMS_TABLE       = "toytalker-llms";
 
   async function saveLog(item) {
     try {
@@ -33,46 +34,20 @@
   const send  = (res, ev, data)=>res.write(`event: ${ev}\ndata: ${JSON.stringify(data)}\n\n`);
   const sha1  = (s)=>createHash("sha1").update(s).digest("hex");
 
-  // ---- 選択モデル定義（まずは OpenAI 固定運用）----
-  const MODEL_DEFAULT = "OpenAI";
-  /** 将来の拡張用にテーブル化しておく（今は OpenAI だけ使う） */
-  const MODEL_TABLE = {
-    // LLM: OpenAI / TTS: OpenAI
-    OpenAI: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "openai",
-      ttsModel:  "gpt-4o-mini-tts",
-    },
-    // LLM: OpenAI / TTS: Google Cloud Text-to-Speech
-    Google: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "google",
-      ttsModel:  "google-tts",
-    },
-    // LLM: OpenAI / TTS: Gemini Speech Generation
-    Gemini: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "gemini",
-      ttsModel:  "gemini-2.5-flash-preview-tts",   // 名称は任意（識別用）
-    },
-    // LLM: OpenAI / TTS: ElevenLabs
-    ElevenLabs: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "elevenlabs",
-      ttsModel:  "eleven_turbo_v2_5",
-    },
-    // LLM: OpenAI / TTS: Fish Audio
-    FishAudio: {
-      llmVendor: "openai",
-      llmModel:  "gpt-4.1-mini",
-      ttsVendor: "fishaudio",
-      ttsModel:  "fishaudio",
-    },
+  // ---- TTS設定（プロバイダーごと）----
+  const TTS_DEFAULT = "OpenAI";
+  const TTS_TABLE = {
+    OpenAI:     { ttsVendor: "openai",     ttsModel: "gpt-4o-mini-tts" },
+    Google:     { ttsVendor: "google",     ttsModel: "google-tts" },
+    Gemini:     { ttsVendor: "gemini",     ttsModel: "gemini-2.5-flash-preview-tts" },
+    ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
+    FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
+    Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
   };
+
+  // ---- LLMデフォルト（llm_id未設定時のフォールバック）----
+  const LLM_DEFAULT_PROVIDER = "openai";
+  const LLM_DEFAULT_MODEL    = "gpt-4.1-mini";
 
 
 
@@ -351,9 +326,32 @@
     return { model: cfg.ttsModel, voiceId };
   }
 
+  // Sakura Internet TTS (VOICEVOX) → base64(WAV)
+  async function ttsToBase64Sakura(text, { model = "zundamon", style = "normal" } = {}) {
+    const key = process.env.SAKURA_API_KEY;
+    if (!key) throw new Error("SAKURA_API_KEY is not set");
+    const resp = await fetch("https://api.ai.sakura.ad.jp/v1/audio/speech", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${key}`,
+        "Content-Type": "application/json",
+        "Accept": "audio/wav",
+      },
+      body: JSON.stringify({
+        model,
+        input: text,
+        voice: style,
+        response_format: "wav",
+      }),
+    });
+    if (!resp.ok) {
+      const errorText = await resp.text();
+      throw new Error(`Sakura TTS failed: ${resp.status} ${errorText}`);
+    }
+    const wavBuffer = Buffer.from(await resp.arrayBuffer());
+    return wavBuffer.toString("base64");
+  }
 
-
-  // character_id → voice(provider + vendor_id) + personality_prompt を解決
   async function resolveCharacterFromDynamo(characterId) {
     try {
       const charRes = await ddb.send(new GetCommand({
@@ -364,6 +362,7 @@
 
       const voiceId = charRes.Item.voice_id;
       const personalityPrompt = charRes.Item.personality_prompt || null;
+      const llmId = charRes.Item.llm_id ?? null;
       if (!voiceId) return null;
 
       const voiceRes = await ddb.send(new GetCommand({
@@ -372,10 +371,25 @@
       }));
       if (!voiceRes.Item) return null;
 
+      let llmProvider = LLM_DEFAULT_PROVIDER;
+      let llmModelId  = LLM_DEFAULT_MODEL;
+      if (llmId) {
+        const llmRes = await ddb.send(new GetCommand({
+          TableName: LLMS_TABLE,
+          Key: { llm_id: llmId },
+        }));
+        if (llmRes.Item) {
+          llmProvider = llmRes.Item.provider;
+          llmModelId  = llmRes.Item.model_id;
+        }
+      }
+
       return {
         provider: voiceRes.Item.provider,
         vendorId: voiceRes.Item.vendor_id,
         personalityPrompt,
+        llmProvider,
+        llmModelId,
       };
     } catch (e) {
       console.error("[DynamoDB] resolveCharacterFromDynamo error:", e);
@@ -389,9 +403,11 @@
     const body      = event.body ? JSON.parse(event.body) : {};
     const messages  = body.messages ?? [{ role:"user", content:"自己紹介して" }];
     const rawModel  = typeof body.model === "string" ? body.model : undefined;
-    let modelKey    = normalizeModelKey(rawModel) ?? MODEL_DEFAULT;
+    let ttsKey      = normalizeModelKey(rawModel) ?? TTS_DEFAULT;
     let voice       = body.voice ?? VOICE_DEFAULT;
     let personalityPrompt = null;
+    let llmProvider = LLM_DEFAULT_PROVIDER;
+    let llmModelId  = LLM_DEFAULT_MODEL;
 
     // ---- ログ用メタデータ ----
     const sessionId  = typeof body.session_id === "string" ? body.session_id : "unknown";
@@ -400,19 +416,20 @@
     const requestAt  = Date.now();
     const userTimestamp = new Date(requestAt).toISOString();
 
-    // character_id が来たら DynamoDB でキャラクター → ボイスを解決
     const characterId = typeof body.character_id === "string" ? body.character_id : null;
     if (characterId && characterId !== "default") {
       const charConfig = await resolveCharacterFromDynamo(characterId);
       if (charConfig) {
-        modelKey = normalizeModelKey(charConfig.provider) ?? modelKey;
+        ttsKey = normalizeModelKey(charConfig.provider) ?? ttsKey;
         voice    = charConfig.vendorId ?? voice;
         personalityPrompt = charConfig.personalityPrompt;
-        console.log(`[Character] id=${characterId}, provider=${charConfig.provider}, vendorId=${charConfig.vendorId}`);
+        llmProvider = charConfig.llmProvider;
+        llmModelId  = charConfig.llmModelId;
+        console.log(`[Character] id=${characterId}, tts=${charConfig.provider}, voice=${charConfig.vendorId}, llm=${llmProvider}/${llmModelId}`);
       }
     }
 
-    const cfg = MODEL_TABLE[modelKey] ?? MODEL_TABLE[MODEL_DEFAULT];
+    const cfg = TTS_TABLE[ttsKey] ?? TTS_TABLE[TTS_DEFAULT];
 
     // ---- ユーザーメッセージ保存 ----
     const lastUserMsg = messages[messages.length - 1];
@@ -434,13 +451,14 @@
       if (s.includes("gemini"))      return "Gemini";
       if (s.includes("elevenlabs"))  return "ElevenLabs";
       if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
-      return undefined; // 不明ならデフォルトにフォールバック
+      if (s.includes("sakura"))      return "Sakura";
+      return undefined;
     }
 
 
-    // クライアント側の計測・デバッグ用に「採用モデル」を通知
-    send(res, "mark", { k: "model", v: modelKey });
-    send(res, "mark", { k: "llm_vendor", v: cfg.llmVendor });
+    send(res, "mark", { k: "model", v: ttsKey });
+    send(res, "mark", { k: "llm_vendor", v: llmProvider });
+    send(res, "mark", { k: "llm_model", v: llmModelId });
     send(res, "mark", { k: "tts_vendor", v: cfg.ttsVendor });
 
     // サーバ基準時刻（クライアントがREQ_TTFBやLLM/TTSとの相対を取れる）
@@ -452,35 +470,10 @@
     if (DEBUG_TIME) {
       send(res, "mark", { k: "llm_start", t: Date.now() });
     }
-    // キャラクターの性格 + 共通システムプロンプトを結合
-    const basePrompt = "あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。";
+    const now = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo", year: "numeric", month: "long", day: "numeric", weekday: "short", hour: "2-digit", minute: "2-digit" });
+    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。相手が話した言語で返答してください。`;
     const systemContent = personalityPrompt ? `${personalityPrompt}\n\n${basePrompt}` : basePrompt;
     const messagesWithSystem = [{ role: "system", content: systemContent }, ...messages];
-
-    let llmStream;
-    if (cfg.llmVendor === "openai") {
-      const llm = await openai.chat.completions.create({
-        model: cfg.llmModel,
-        temperature: 0.7,
-        stream: true,
-        stream_options: { include_usage: true },
-        messages: messagesWithSystem,
-      });
-      llmStream = (async function* () {
-        for await (const chunk of llm) {
-          if (chunk.usage) {
-            llmTokensIn  = chunk.usage.prompt_tokens     ?? 0;
-            llmTokensOut = chunk.usage.completion_tokens ?? 0;
-          }
-          const delta = chunk.choices?.[0]?.delta?.content ?? "";
-          if (delta) yield delta;
-        }
-      })();
-    } else {
-    // もし将来 Gemini LLM に切り替えるならここで実装
-    const fallback = "（LLM ルート未実装です）";
-    llmStream = (async function* () { yield fallback; })();
-  }
 
     // ---- ストリーム状態 ----
     let buf = "";
@@ -490,6 +483,153 @@
     let firstTtsMarked = false;
     let llmTokensIn = 0, llmTokensOut = 0;
     let ttsInputChars = 0;
+
+    // ---- LLM ストリーム生成 ----
+    function streamLLMOpenAI(msgs, model) {
+      return (async function* () {
+        const llm = await openai.chat.completions.create({
+          model,
+          temperature: 0.7,
+          stream: true,
+          stream_options: { include_usage: true },
+          messages: msgs,
+        });
+        for await (const chunk of llm) {
+          if (chunk.usage) {
+            llmTokensIn  = chunk.usage.prompt_tokens     ?? 0;
+            llmTokensOut = chunk.usage.completion_tokens ?? 0;
+          }
+          const delta = chunk.choices?.[0]?.delta?.content ?? "";
+          if (delta) yield delta;
+        }
+      })();
+    }
+
+    function streamLLMGemini(msgs, model) {
+      const systemMsg = msgs.find(m => m.role === "system");
+      const chatMsgs = msgs.filter(m => m.role !== "system");
+      const contents = chatMsgs.map(m => ({
+        role: m.role === "assistant" ? "model" : m.role,
+        parts: [{ text: m.content }],
+      }));
+      const reqBody = { contents };
+      if (systemMsg) {
+        reqBody.systemInstruction = { parts: [{ text: systemMsg.content }] };
+      }
+      reqBody.generationConfig = { temperature: 0.7 };
+
+      const key = process.env.GOOGLE_API_KEY;
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${key}`;
+
+      return (async function* () {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(reqBody),
+        });
+        if (!resp.ok) {
+          const errText = await resp.text();
+          throw new Error(`Gemini API error: ${resp.status} ${errText}`);
+        }
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let sbuf = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          sbuf += decoder.decode(value, { stream: true });
+          const lines = sbuf.split("\n");
+          sbuf = lines.pop();
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            const data = line.slice(6).trim();
+            if (data === "[DONE]") return;
+            try {
+              const parsed = JSON.parse(data);
+              const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+              if (parsed.usageMetadata) {
+                llmTokensIn  = parsed.usageMetadata.promptTokenCount ?? 0;
+                llmTokensOut = parsed.usageMetadata.candidatesTokenCount ?? 0;
+              }
+              if (text) yield text;
+            } catch {}
+          }
+        }
+      })();
+    }
+
+    function streamLLMAnthropic(msgs, model) {
+      const systemMsg = msgs.find(m => m.role === "system");
+      const chatMsgs = msgs.filter(m => m.role !== "system");
+
+      const reqBody = {
+        model,
+        max_tokens: 1024,
+        stream: true,
+        temperature: 0.7,
+        messages: chatMsgs,
+      };
+      if (systemMsg) {
+        reqBody.system = systemMsg.content;
+      }
+
+      const key = process.env.ANTHROPIC_API_KEY;
+
+      return (async function* () {
+        const resp = await fetch("https://api.anthropic.com/v1/messages", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-api-key": key,
+            "anthropic-version": "2023-06-01",
+          },
+          body: JSON.stringify(reqBody),
+        });
+        if (!resp.ok) {
+          const errText = await resp.text();
+          throw new Error(`Anthropic API error: ${resp.status} ${errText}`);
+        }
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let sbuf = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          sbuf += decoder.decode(value, { stream: true });
+          const lines = sbuf.split("\n");
+          sbuf = lines.pop();
+          for (const line of lines) {
+            if (!line.startsWith("data: ")) continue;
+            const data = line.slice(6).trim();
+            try {
+              const parsed = JSON.parse(data);
+              if (parsed.type === "content_block_delta") {
+                const text = parsed.delta?.text ?? "";
+                if (text) yield text;
+              } else if (parsed.type === "message_delta" && parsed.usage) {
+                llmTokensOut = parsed.usage.output_tokens ?? 0;
+              } else if (parsed.type === "message_start" && parsed.message?.usage) {
+                llmTokensIn = parsed.message.usage.input_tokens ?? 0;
+              } else if (parsed.type === "message_stop") {
+                return;
+              }
+            } catch {}
+          }
+        }
+      })();
+    }
+
+    let llmStream;
+    if (llmProvider === "openai") {
+      llmStream = streamLLMOpenAI(messagesWithSystem, llmModelId);
+    } else if (llmProvider === "google") {
+      llmStream = streamLLMGemini(messagesWithSystem, llmModelId);
+    } else if (llmProvider === "anthropic") {
+      llmStream = streamLLMAnthropic(messagesWithSystem, llmModelId);
+    } else {
+      const fallback = "（LLM ルート未実装です）";
+      llmStream = (async function* () { yield fallback; })();
+    }
 
     // segment を送る唯一の経路
     async function emitSegment(text, { final=false } = {}) {
@@ -538,6 +678,10 @@
           if (voice) f.referenceId = voice;
           b64 = await ttsToBase64FishAudio(t, f);
           fmt = "mp3";
+        } else if (cfg.ttsVendor === "sakura") {
+          const modelName = voice === "default" ? "zundamon" : voice;
+          b64 = await ttsToBase64Sakura(t, { model: modelName });
+          fmt = "wav";
         } else {
           throw new Error("Unknown ttsVendor");
         }
@@ -577,7 +721,7 @@
           owner_id: ownerId, device_id: deviceId, source: "app",
           role: "assistant", content: textAll.trim(),
           content_type: "text", timestamp: assistantTimestamp, session_id: sessionId,
-          llm_provider: cfg.llmVendor, llm_model: cfg.llmModel,
+          llm_provider: llmProvider, llm_model: llmModelId,
           llm_tokens_in: llmTokensIn, llm_tokens_out: llmTokensOut,
           tts_provider: cfg.ttsVendor, tts_input_units: ttsInputChars, tts_input_unit_type: "characters",
           stt_provider: null, stt_input_units: null, stt_input_unit_type: null,

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -12,6 +12,7 @@ const DEVICES_TABLE    = "toytalker-devices";
 const VOICES_TABLE     = "toytalker-voices";
 const CHARACTERS_TABLE = "toytalker-characters";
 const CHAT_LOGS_TABLE  = "toytalker-chat-logs";
+const LLMS_TABLE       = "toytalker-llms";
 
 const response = (statusCode, body) => ({
   statusCode,
@@ -26,6 +27,12 @@ export const handler = async (event) => {
   console.log(`[Request] ${method} ${path}`);
 
   try {
+
+    // ---- GET /llms ---- LLM一覧取得
+    if (method === "GET" && path === "/llms") {
+      const result = await ddb.send(new ScanCommand({ TableName: LLMS_TABLE }));
+      return response(200, { llms: result.Items ?? [] });
+    }
 
     // ---- GET /voices ---- ボイス一覧取得
     if (method === "GET" && path === "/voices") {
@@ -50,7 +57,7 @@ export const handler = async (event) => {
     // ---- POST /characters ---- キャラクター作成
     if (method === "POST" && path === "/characters") {
       const body = JSON.parse(event.body ?? "{}");
-      const { name, description = "", personality_prompt = "", voice_id = "elevenlabs_sameno", owner_id = "user_123" } = body;
+      const { name, description = "", personality_prompt = "", voice_id = "elevenlabs_sameno", llm_id = "openai_gpt41mini", owner_id = "user_123" } = body;
       if (!name) return response(400, { error: "name is required" });
 
       const character_id = `${owner_id}_${Date.now()}`;
@@ -63,6 +70,7 @@ export const handler = async (event) => {
           description,
           personality_prompt,
           voice_id,
+          llm_id,
           created_at: new Date().toISOString(),
         },
       }));
@@ -83,6 +91,7 @@ export const handler = async (event) => {
       if (description       !== undefined) { updates.push("#ds = :d");  names["#ds"] = "description"; vals[":d"] = description; }
       if (personality_prompt !== undefined) { updates.push("personality_prompt = :p");                 vals[":p"] = personality_prompt; }
       if (voice_id          !== undefined) { updates.push("voice_id = :v");                            vals[":v"] = voice_id; }
+      if (body.llm_id       !== undefined) { updates.push("llm_id = :l");                              vals[":l"] = body.llm_id; }
       if (updates.length === 0) return response(400, { error: "No fields to update" });
 
       await ddb.send(new UpdateCommand({


### PR DESCRIPTION
## Summary
- キャラクターごとにLLMプロバイダーを選択可能に（GPT-4.1 mini / Gemini 2.5 Flash / Claude Haiku 4.5）
- `toytalker-llms` DynamoDBテーブルでLLM設定を管理（voicesと同パターン）
- 3つのLambda全てに対応: Device Setting / ESP32 Stream / App Stream
- アプリのキャラクター編集画面にLLM選択UIを追加（プロバイダーごとにセクション分け）
- Sakura TTSをApp用Lambdaにも追加
- LLMストリームの文末分割を改善（句読点で即分割→TTS高速化）
- 日本語間の不要スペースをTTS前に除去
- basePromptに日時認識・多言語対応・スペース除去指示を追加
- 戻るボタンを「←」アイコンに統一 + hitSlopでタップ改善
- 保存/削除ボタンの順序を入れ替え

## Performance
- Claude Haiku 4.5: 初回音声1秒台安定、品質スコア最高（31点）
- Gemini 2.5 Flash: 最安コスト、調子が良いと1秒台
- 10分会話の全コスト: 最安構成で約4円、品質重視でも約9円

## Test plan
- [x] ESP32でOpenAI/Gemini/Anthropic各LLMの会話動作確認
- [x] アプリでLLM選択→会話動作確認
- [x] llm_id未設定キャラのフォールバック確認（OpenAIにデフォルト）
- [x] Sakura TTS動作確認（App Lambda）

🤖 Generated with [Claude Code](https://claude.com/claude-code)