### PR TITLE
Add usage tracking and cost dashboard

### DIFF
--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -204,8 +204,7 @@ export default function Settings() {
     setUsageDetailData(null);
     setUsageDetailLoading(true);
     navigateTo("usage-detail");
-    // 全デバイス分を取得するため、device_idを省略して"app"をデフォルトで取得
-    // TODO: 複数デバイス対応
+    if (characters.length === 0) loadCharacters();
     fetch(`${DEVICE_SETTING_URL}/usage/detail?owner_id=${encodeURIComponent(ownerId)}&date=${date}&device_id=app`)
       .then(r => r.json())
       .then(data => setUsageDetailData(data))
@@ -387,9 +386,17 @@ export default function Settings() {
                 {/* 会話ごとの詳細 */}
                 {convos.map((c: any, i: number) => {
                   const time = c.timestamp?.slice(11, 19) ?? "";
+                  const charName = characters.find(ch => ch.character_id === c.character_id)?.name ?? c.character_id ?? "";
+                  const devLabel = usageDetailData?.device_id === "app" ? "アプリ" : (usageDetailData?.device_id ?? "");
                   return (
                     <View key={i} style={s.detailCard}>
-                      <Text style={s.detailTime}>{time}</Text>
+                      <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+                        <Text style={s.detailTime}>{time}</Text>
+                        <View style={{ flexDirection: "row", gap: 8 }}>
+                          {charName ? <Text style={s.detailMeta}>{charName}</Text> : null}
+                          {devLabel ? <Text style={s.detailMeta}>{devLabel}</Text> : null}
+                        </View>
+                      </View>
                       {c.user_message && (
                         <Text style={s.detailUserMsg} numberOfLines={2}>{c.user_message}</Text>
                       )}
@@ -525,7 +532,7 @@ export default function Settings() {
                               <View style={[s.dailyBarFill, { flex: cost / maxCost }]} />
                               <View style={{ flex: 1 - cost / maxCost }} />
                             </View>
-                            <Text style={s.dailyBarCost}>{formatCost(cost)}</Text>
+                            <Text style={s.dailyBarCost}>{formatCost(cost)} 円</Text>
                             <Text style={s.chevronSmall}>›</Text>
                           </TouchableOpacity>
                         ))}
@@ -1034,10 +1041,11 @@ const s = StyleSheet.create({
   dailyBarDate:            { fontSize: 12, color: "#666", width: 32, textAlign: "right", marginRight: 8 },
   dailyBarTrack:           { flex: 1, flexDirection: "row", height: 14, borderRadius: 7, backgroundColor: "#f0f0f0", overflow: "hidden" },
   dailyBarFill:            { backgroundColor: "#007AFF", borderRadius: 7 },
-  dailyBarCost:            { fontSize: 12, color: "#333", width: 50, textAlign: "right", marginLeft: 6 },
+  dailyBarCost:            { fontSize: 12, color: "#007AFF", width: 58, textAlign: "right", marginLeft: 6 },
   // 利用状況詳細
   detailCard:              { backgroundColor: "#f9f9f9", padding: 14, borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0" },
   detailTime:              { fontSize: 14, fontWeight: "700", color: "#333" },
+  detailMeta:              { fontSize: 11, color: "#999", backgroundColor: "#f0f0f0", paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4, overflow: "hidden" },
   detailUserMsg:           { fontSize: 13, color: "#666", marginTop: 4, fontStyle: "italic" },
   detailCostList:          { marginTop: 8, gap: 4 },
   detailCostRow:           { flexDirection: "row", alignItems: "center" },

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -503,6 +503,37 @@ export default function Settings() {
                   </>
                 )}
 
+                {/* 日別グラフ */}
+                {(() => {
+                  const dailyTotals: Record<string, number> = {};
+                  for (const apiType of ["stt", "llm", "tts"]) {
+                    for (const d of byApi[apiType]?.daily ?? []) {
+                      dailyTotals[d.date] = (dailyTotals[d.date] ?? 0) + (d.cost ?? 0);
+                    }
+                  }
+                  const days = Object.entries(dailyTotals).sort((a, b) => a[0].localeCompare(b[0]));
+                  if (days.length === 0) return null;
+                  const maxCost = Math.max(...days.map(([, c]) => c), 0.001);
+                  return (
+                    <>
+                      <Text style={[s.sectionTitle, { marginTop: 16 }]}>日別</Text>
+                      <View style={s.usageApiCard}>
+                        {days.map(([date, cost]) => (
+                          <TouchableOpacity key={date} style={s.dailyBarRow} onPress={() => openUsageDetail(date)} activeOpacity={0.7}>
+                            <Text style={s.dailyBarDate}>{date.slice(8)}日</Text>
+                            <View style={s.dailyBarTrack}>
+                              <View style={[s.dailyBarFill, { flex: cost / maxCost }]} />
+                              <View style={{ flex: 1 - cost / maxCost }} />
+                            </View>
+                            <Text style={s.dailyBarCost}>{formatCost(cost)}</Text>
+                            <Text style={s.chevronSmall}>›</Text>
+                          </TouchableOpacity>
+                        ))}
+                      </View>
+                    </>
+                  );
+                })()}
+
                 {/* API種別カード */}
                 <Text style={[s.sectionTitle, { marginTop: 16 }]}>API種別</Text>
                 {["stt", "llm", "tts"].map((apiType) => {
@@ -531,12 +562,11 @@ export default function Settings() {
                       {isExpanded && dailySorted.length > 0 && (
                         <View style={s.usageDailyList}>
                           {dailySorted.map(([date, info]) => (
-                            <TouchableOpacity key={date} style={s.usageDailyRow} onPress={() => openUsageDetail(date)}>
-                              <Text style={s.usageDailyDateLink}>{date.slice(5)}</Text>
+                            <View key={date} style={s.usageDailyRow}>
+                              <Text style={s.usageDailyDate}>{date.slice(5)}</Text>
                               <Text style={s.usageDailyRequests}>{info.requests}回</Text>
                               <Text style={s.usageDailyCost}>{formatCost(info.cost)} 円</Text>
-                              <Text style={s.chevronSmall}>›</Text>
-                            </TouchableOpacity>
+                            </View>
                           ))}
                         </View>
                       )}
@@ -1000,6 +1030,11 @@ const s = StyleSheet.create({
   usageRateText:           { fontSize: 12, color: "#999", textAlign: "center", marginTop: 16 },
   usageDailyDateLink:      { fontSize: 13, color: "#007AFF", flex: 1 },
   chevronSmall:            { fontSize: 14, color: "#999", marginLeft: 4 },
+  dailyBarRow:             { flexDirection: "row", alignItems: "center", paddingVertical: 5 },
+  dailyBarDate:            { fontSize: 12, color: "#666", width: 32, textAlign: "right", marginRight: 8 },
+  dailyBarTrack:           { flex: 1, flexDirection: "row", height: 14, borderRadius: 7, backgroundColor: "#f0f0f0", overflow: "hidden" },
+  dailyBarFill:            { backgroundColor: "#007AFF", borderRadius: 7 },
+  dailyBarCost:            { fontSize: 12, color: "#333", width: 50, textAlign: "right", marginLeft: 6 },
   // 利用状況詳細
   detailCard:              { backgroundColor: "#f9f9f9", padding: 14, borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0" },
   detailTime:              { fontSize: 14, fontWeight: "700", color: "#333" },

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -553,7 +553,7 @@ export default function Settings() {
                     dailyMap[d.date].cost += d.cost;
                     dailyMap[d.date].requests += d.requests ?? 0;
                   }
-                  const dailySorted = Object.entries(dailyMap).sort((a, b) => b[0].localeCompare(a[0]));
+                  const dailySorted = Object.entries(dailyMap).sort((a, b) => a[0].localeCompare(b[0]));
 
                   return (
                     <TouchableOpacity

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -205,7 +205,7 @@ export default function Settings() {
     setUsageDetailLoading(true);
     navigateTo("usage-detail");
     if (characters.length === 0) loadCharacters();
-    fetch(`${DEVICE_SETTING_URL}/usage/detail?owner_id=${encodeURIComponent(ownerId)}&date=${date}&device_id=app`)
+    fetch(`${DEVICE_SETTING_URL}/usage/detail?owner_id=${encodeURIComponent(ownerId)}&date=${date}`)
       .then(r => r.json())
       .then(data => setUsageDetailData(data))
       .catch(e => console.error("[UsageDetail] error:", e))
@@ -385,9 +385,9 @@ export default function Settings() {
 
                 {/* 会話ごとの詳細 */}
                 {convos.map((c: any, i: number) => {
-                  const time = c.timestamp?.slice(11, 19) ?? "";
+                  const time = c.timestamp ? new Date(c.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" }) : "";
                   const charName = characters.find(ch => ch.character_id === c.character_id)?.name ?? c.character_id ?? "";
-                  const devLabel = usageDetailData?.device_id === "app" ? "アプリ" : (usageDetailData?.device_id ?? "");
+                  const devLabel = c.device_id === "app" ? "アプリ" : (c.device_id ?? "");
                   return (
                     <View key={i} style={s.detailCard}>
                       <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -19,7 +19,7 @@ import { useOwnerId } from "../../hooks/useOwnerId";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
-type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "llm-select" | "version" | "usage";
+type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "llm-select" | "version" | "usage" | "usage-detail";
 
 type CharacterItem = {
   character_id: string;
@@ -104,6 +104,9 @@ export default function Settings() {
   const [usageMonth, setUsageMonth] = useState(() => new Date().toISOString().slice(0, 7));
   const [expandedApi, setExpandedApi] = useState<string | null>(null);
   const [expandedDevice, setExpandedDevice] = useState<string | null>(null);
+  const [usageDetailData, setUsageDetailData] = useState<any>(null);
+  const [usageDetailLoading, setUsageDetailLoading] = useState(false);
+  const [usageDetailDate, setUsageDetailDate] = useState("");
 
   useEffect(() => {
     (async () => {
@@ -158,6 +161,57 @@ export default function Settings() {
   };
 
   const API_LABELS: Record<string, string> = { llm: "LLM（言語モデル）", tts: "TTS（音声合成）", stt: "STT（音声認識）" };
+
+  const CHART_COLORS: Record<string, string> = {
+    stt: "#34C759", llm: "#007AFF", tts: "#FF9500",
+    // プロバイダ別の色
+    openai: "#10A37F", google: "#4285F4", gemini: "#886FBF",
+    anthropic: "#D97706", elevenlabs: "#F472B6", fishaudio: "#6366F1",
+    sakura: "#EC4899", soniox: "#34C759",
+  };
+
+  type PieSlice = { label: string; value: number; color: string };
+
+  const PieChart = ({ slices }: { slices: PieSlice[] }) => {
+    const total = slices.reduce((s, d) => s + d.value, 0);
+    if (total <= 0) return null;
+    const filtered = slices.filter(d => d.value > 0).map(d => ({ ...d, pct: d.value / total }));
+
+    return (
+      <View style={{ alignItems: "center", marginVertical: 12 }}>
+        <Text style={{ fontSize: 12, color: "#999", marginBottom: 4 }}>合計</Text>
+        <Text style={{ fontSize: 20, fontWeight: "700", color: "#333", marginBottom: 12 }}>{formatCost(total)}円</Text>
+        <View style={{ flexDirection: "row", width: "100%", height: 20, borderRadius: 10, overflow: "hidden", backgroundColor: "#f0f0f0" }}>
+          {filtered.map((seg, i) => (
+            <View key={i} style={{ flex: seg.pct, backgroundColor: seg.color }} />
+          ))}
+        </View>
+        <View style={s.legendRow}>
+          {filtered.map((p, i) => (
+            <View key={i} style={s.legendItem}>
+              <View style={[s.legendDot, { backgroundColor: p.color }]} />
+              <Text style={s.legendText}>{p.label} {Math.round(p.pct * 100)}% ({formatCost(p.value)}円)</Text>
+            </View>
+          ))}
+        </View>
+      </View>
+    );
+  };
+
+  const openUsageDetail = (date: string) => {
+    if (!ownerId) return;
+    setUsageDetailDate(date);
+    setUsageDetailData(null);
+    setUsageDetailLoading(true);
+    navigateTo("usage-detail");
+    // 全デバイス分を取得するため、device_idを省略して"app"をデフォルトで取得
+    // TODO: 複数デバイス対応
+    fetch(`${DEVICE_SETTING_URL}/usage/detail?owner_id=${encodeURIComponent(ownerId)}&date=${date}&device_id=app`)
+      .then(r => r.json())
+      .then(data => setUsageDetailData(data))
+      .catch(e => console.error("[UsageDetail] error:", e))
+      .finally(() => setUsageDetailLoading(false));
+  };
 
   const handleSttChange = async (value: "local" | "soniox") => {
     setSttMode(value);
@@ -285,6 +339,98 @@ export default function Settings() {
     }
   };
 
+  // ---- 利用状況詳細画面（日次） ----
+  if (screen === "usage-detail") {
+    const convos = usageDetailData?.conversations ?? [];
+    return (
+      <SafeAreaView style={s.root}>
+        <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
+          <View style={s.header}>
+            <TouchableOpacity onPress={() => navigateTo("usage", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+              <Text style={s.back}>←</Text>
+            </TouchableOpacity>
+            <Text style={s.headerTitle}>{usageDetailDate} の詳細</Text>
+          </View>
+          <ScrollView contentContainerStyle={s.wrap}>
+            {usageDetailLoading ? (
+              <ActivityIndicator style={{ marginTop: 32 }} />
+            ) : convos.length === 0 ? (
+              <Text style={s.emptyText}>この日の会話データはありません</Text>
+            ) : (
+              <>
+                {/* 円グラフ: API種別×プロバイダ */}
+                {(() => {
+                  const sliceMap: Record<string, { label: string; value: number; color: string }> = {};
+                  for (const c of convos) {
+                    if (c.stt?.cost) {
+                      const key = "STT";
+                      if (!sliceMap[key]) sliceMap[key] = { label: key, value: 0, color: CHART_COLORS.stt };
+                      sliceMap[key].value += c.stt.cost;
+                    }
+                    if (c.llm?.cost) {
+                      const provider = c.llm.provider ?? "llm";
+                      const key = `LLM(${provider})`;
+                      if (!sliceMap[key]) sliceMap[key] = { label: key, value: 0, color: CHART_COLORS[provider] ?? CHART_COLORS.llm };
+                      sliceMap[key].value += c.llm.cost;
+                    }
+                    if (c.tts?.cost) {
+                      const provider = c.tts.provider ?? "tts";
+                      const key = `TTS(${provider})`;
+                      if (!sliceMap[key]) sliceMap[key] = { label: key, value: 0, color: CHART_COLORS[provider] ?? CHART_COLORS.tts };
+                      sliceMap[key].value += c.tts.cost;
+                    }
+                  }
+                  const slices = Object.values(sliceMap).sort((a, b) => b.value - a.value);
+                  return <PieChart slices={slices} />;
+                })()}
+
+                {/* 会話ごとの詳細 */}
+                {convos.map((c: any, i: number) => {
+                  const time = c.timestamp?.slice(11, 19) ?? "";
+                  return (
+                    <View key={i} style={s.detailCard}>
+                      <Text style={s.detailTime}>{time}</Text>
+                      {c.user_message && (
+                        <Text style={s.detailUserMsg} numberOfLines={2}>{c.user_message}</Text>
+                      )}
+                      <View style={s.detailCostList}>
+                        {c.stt && (
+                          <View style={s.detailCostRow}>
+                            <Text style={s.detailCostLabel}>STT</Text>
+                            <Text style={s.detailCostSub}>{c.stt.characters}文字</Text>
+                            <Text style={s.detailCostValue}>{formatCost(c.stt.cost)} 円</Text>
+                          </View>
+                        )}
+                        {c.llm && (
+                          <View style={s.detailCostRow}>
+                            <Text style={s.detailCostLabel}>LLM</Text>
+                            <Text style={s.detailCostSub}>{c.llm.provider} / in:{c.llm.tokens_in} out:{c.llm.tokens_out}</Text>
+                            <Text style={s.detailCostValue}>{formatCost(c.llm.cost)} 円</Text>
+                          </View>
+                        )}
+                        {c.tts && (
+                          <View style={s.detailCostRow}>
+                            <Text style={s.detailCostLabel}>TTS</Text>
+                            <Text style={s.detailCostSub}>{c.tts.provider} / {c.tts.characters}文字</Text>
+                            <Text style={s.detailCostValue}>{formatCost(c.tts.cost)} 円</Text>
+                          </View>
+                        )}
+                      </View>
+                      <View style={s.detailTotalRow}>
+                        <Text style={s.detailTotalLabel}>合計</Text>
+                        <Text style={s.detailTotalValue}>{formatCost(c.total)} 円</Text>
+                      </View>
+                    </View>
+                  );
+                })}
+              </>
+            )}
+          </ScrollView>
+        </Animated.View>
+      </SafeAreaView>
+    );
+  }
+
   // ---- 利用状況画面 ----
   if (screen === "usage") {
     const byApi = usageData?.by_api_type ?? {};
@@ -322,45 +468,6 @@ export default function Settings() {
                   <Text style={s.usageTotalAmount}>{formatCost(usageData?.total_cost ?? 0)} 円</Text>
                 </View>
 
-                {/* API種別カード */}
-                {["stt", "llm", "tts"].map((apiType) => {
-                  const data = byApi[apiType];
-                  if (!data) return null;
-                  const isExpanded = expandedApi === apiType;
-                  const dailyMap: Record<string, { cost: number; requests: number }> = {};
-                  for (const d of data.daily ?? []) {
-                    if (!dailyMap[d.date]) dailyMap[d.date] = { cost: 0, requests: 0 };
-                    dailyMap[d.date].cost += d.cost;
-                    dailyMap[d.date].requests += d.requests ?? 0;
-                  }
-                  const dailySorted = Object.entries(dailyMap).sort((a, b) => b[0].localeCompare(a[0]));
-
-                  return (
-                    <TouchableOpacity
-                      key={apiType}
-                      style={s.usageApiCard}
-                      onPress={() => setExpandedApi(isExpanded ? null : apiType)}
-                      activeOpacity={0.7}
-                    >
-                      <View style={s.usageApiHeader}>
-                        <Text style={s.usageApiLabel}>{API_LABELS[apiType] ?? apiType.toUpperCase()}</Text>
-                        <Text style={s.usageApiCost}>{formatCost(data.total)} 円</Text>
-                      </View>
-                      {isExpanded && dailySorted.length > 0 && (
-                        <View style={s.usageDailyList}>
-                          {dailySorted.map(([date, info]) => (
-                            <View key={date} style={s.usageDailyRow}>
-                              <Text style={s.usageDailyDate}>{date.slice(5)}</Text>
-                              <Text style={s.usageDailyRequests}>{info.requests}回</Text>
-                              <Text style={s.usageDailyCost}>{formatCost(info.cost)} 円</Text>
-                            </View>
-                          ))}
-                        </View>
-                      )}
-                    </TouchableOpacity>
-                  );
-                })}
-
                 {/* デバイス別 */}
                 {Object.keys(byDevice).length > 0 && (
                   <>
@@ -395,6 +502,47 @@ export default function Settings() {
                     })}
                   </>
                 )}
+
+                {/* API種別カード */}
+                <Text style={[s.sectionTitle, { marginTop: 16 }]}>API種別</Text>
+                {["stt", "llm", "tts"].map((apiType) => {
+                  const data = byApi[apiType];
+                  if (!data) return null;
+                  const isExpanded = expandedApi === apiType;
+                  const dailyMap: Record<string, { cost: number; requests: number }> = {};
+                  for (const d of data.daily ?? []) {
+                    if (!dailyMap[d.date]) dailyMap[d.date] = { cost: 0, requests: 0 };
+                    dailyMap[d.date].cost += d.cost;
+                    dailyMap[d.date].requests += d.requests ?? 0;
+                  }
+                  const dailySorted = Object.entries(dailyMap).sort((a, b) => b[0].localeCompare(a[0]));
+
+                  return (
+                    <TouchableOpacity
+                      key={apiType}
+                      style={s.usageApiCard}
+                      onPress={() => setExpandedApi(isExpanded ? null : apiType)}
+                      activeOpacity={0.7}
+                    >
+                      <View style={s.usageApiHeader}>
+                        <Text style={s.usageApiLabel}>{API_LABELS[apiType] ?? apiType.toUpperCase()}</Text>
+                        <Text style={s.usageApiCost}>{formatCost(data.total)} 円</Text>
+                      </View>
+                      {isExpanded && dailySorted.length > 0 && (
+                        <View style={s.usageDailyList}>
+                          {dailySorted.map(([date, info]) => (
+                            <TouchableOpacity key={date} style={s.usageDailyRow} onPress={() => openUsageDetail(date)}>
+                              <Text style={s.usageDailyDateLink}>{date.slice(5)}</Text>
+                              <Text style={s.usageDailyRequests}>{info.requests}回</Text>
+                              <Text style={s.usageDailyCost}>{formatCost(info.cost)} 円</Text>
+                              <Text style={s.chevronSmall}>›</Text>
+                            </TouchableOpacity>
+                          ))}
+                        </View>
+                      )}
+                    </TouchableOpacity>
+                  );
+                })}
 
                 {/* 為替レート */}
                 {rate && (
@@ -850,4 +998,23 @@ const s = StyleSheet.create({
   usageDailyRequests:      { fontSize: 13, color: "#999", marginRight: 12 },
   usageDailyCost:          { fontSize: 13, fontWeight: "600", color: "#333" },
   usageRateText:           { fontSize: 12, color: "#999", textAlign: "center", marginTop: 16 },
+  usageDailyDateLink:      { fontSize: 13, color: "#007AFF", flex: 1 },
+  chevronSmall:            { fontSize: 14, color: "#999", marginLeft: 4 },
+  // 利用状況詳細
+  detailCard:              { backgroundColor: "#f9f9f9", padding: 14, borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0" },
+  detailTime:              { fontSize: 14, fontWeight: "700", color: "#333" },
+  detailUserMsg:           { fontSize: 13, color: "#666", marginTop: 4, fontStyle: "italic" },
+  detailCostList:          { marginTop: 8, gap: 4 },
+  detailCostRow:           { flexDirection: "row", alignItems: "center" },
+  detailCostLabel:         { fontSize: 12, fontWeight: "600", color: "#555", width: 32 },
+  detailCostSub:           { fontSize: 11, color: "#999", flex: 1 },
+  detailCostValue:         { fontSize: 13, fontWeight: "600", color: "#333" },
+  detailTotalRow:          { flexDirection: "row", justifyContent: "space-between", marginTop: 8, paddingTop: 8, borderTopWidth: 1, borderTopColor: "#e0e0e0" },
+  detailTotalLabel:        { fontSize: 13, fontWeight: "600", color: "#333" },
+  detailTotalValue:        { fontSize: 14, fontWeight: "700", color: "#007AFF" },
+  // 円グラフ凡例
+  legendRow:               { flexDirection: "row", flexWrap: "wrap", justifyContent: "center", gap: 8, marginTop: 12 },
+  legendItem:              { flexDirection: "row", alignItems: "center", gap: 4 },
+  legendDot:               { width: 10, height: 10, borderRadius: 5 },
+  legendText:              { fontSize: 11, color: "#666" },
 });

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -19,7 +19,7 @@ import { useOwnerId } from "../../hooks/useOwnerId";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
-type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "llm-select" | "version";
+type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "llm-select" | "version" | "usage";
 
 type CharacterItem = {
   character_id: string;
@@ -98,12 +98,66 @@ export default function Settings() {
   const [llms, setLlms] = useState<LlmItem[]>([]);
   const [llmsLoading, setLlmsLoading] = useState(false);
 
+  // 利用状況
+  const [usageData, setUsageData] = useState<any>(null);
+  const [usageLoading, setUsageLoading] = useState(false);
+  const [usageMonth, setUsageMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [expandedApi, setExpandedApi] = useState<string | null>(null);
+  const [expandedDevice, setExpandedDevice] = useState<string | null>(null);
+
   useEffect(() => {
     (async () => {
       const saved = await AsyncStorage.getItem("sttMode");
       if (saved === "local" || saved === "soniox") setSttMode(saved);
     })();
   }, []);
+
+  const loadUsage = async (month: string) => {
+    if (!ownerId) return;
+    setUsageLoading(true);
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/usage?owner_id=${encodeURIComponent(ownerId)}&month=${month}`);
+      const data = await res.json();
+      setUsageData(data);
+    } catch (e) {
+      console.error("[Usage] error:", e);
+    } finally {
+      setUsageLoading(false);
+    }
+  };
+
+  const openUsage = () => {
+    const month = new Date().toISOString().slice(0, 7);
+    setUsageMonth(month);
+    setExpandedApi(null);
+    setExpandedDevice(null);
+    loadUsage(month);
+    navigateTo("usage");
+  };
+
+  const changeMonth = (delta: number) => {
+    const [y, m] = usageMonth.split("-").map(Number);
+    const d = new Date(y, m - 1 + delta, 1);
+    const next = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    setUsageMonth(next);
+    setExpandedApi(null);
+    setExpandedDevice(null);
+    loadUsage(next);
+  };
+
+  const formatCost = (v: number) => {
+    if (v >= 1) return `${Math.round(v * 10) / 10}`;
+    if (v >= 0.01) return v.toFixed(2);
+    if (v > 0) return v.toFixed(3);
+    return "0";
+  };
+
+  const formatMonthLabel = (month: string) => {
+    const [y, m] = month.split("-");
+    return `${y}年${parseInt(m)}月`;
+  };
+
+  const API_LABELS: Record<string, string> = { llm: "LLM（言語モデル）", tts: "TTS（音声合成）", stt: "STT（音声認識）" };
 
   const handleSttChange = async (value: "local" | "soniox") => {
     setSttMode(value);
@@ -230,6 +284,135 @@ export default function Settings() {
       setSaving(false);
     }
   };
+
+  // ---- 利用状況画面 ----
+  if (screen === "usage") {
+    const byApi = usageData?.by_api_type ?? {};
+    const byDevice = usageData?.by_device ?? {};
+    const rate = usageData?.exchange_rate;
+
+    return (
+      <SafeAreaView style={s.root}>
+        <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
+          <View style={s.header}>
+            <TouchableOpacity onPress={() => navigateTo("main", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+              <Text style={s.back}>←</Text>
+            </TouchableOpacity>
+            <Text style={s.headerTitle}>利用状況</Text>
+          </View>
+          <ScrollView contentContainerStyle={s.wrap}>
+            {/* 月選択 */}
+            <View style={s.usageMonthRow}>
+              <TouchableOpacity onPress={() => changeMonth(-1)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+                <Text style={s.usageMonthArrow}>←</Text>
+              </TouchableOpacity>
+              <Text style={s.usageMonthText}>{formatMonthLabel(usageMonth)}</Text>
+              <TouchableOpacity onPress={() => changeMonth(1)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+                <Text style={s.usageMonthArrow}>→</Text>
+              </TouchableOpacity>
+            </View>
+
+            {usageLoading ? (
+              <ActivityIndicator style={{ marginTop: 32 }} />
+            ) : (
+              <>
+                {/* 合計 */}
+                <View style={s.usageTotalCard}>
+                  <Text style={s.usageTotalLabel}>今月の合計</Text>
+                  <Text style={s.usageTotalAmount}>{formatCost(usageData?.total_cost ?? 0)} 円</Text>
+                </View>
+
+                {/* API種別カード */}
+                {["stt", "llm", "tts"].map((apiType) => {
+                  const data = byApi[apiType];
+                  if (!data) return null;
+                  const isExpanded = expandedApi === apiType;
+                  const dailyMap: Record<string, { cost: number; requests: number }> = {};
+                  for (const d of data.daily ?? []) {
+                    if (!dailyMap[d.date]) dailyMap[d.date] = { cost: 0, requests: 0 };
+                    dailyMap[d.date].cost += d.cost;
+                    dailyMap[d.date].requests += d.requests ?? 0;
+                  }
+                  const dailySorted = Object.entries(dailyMap).sort((a, b) => b[0].localeCompare(a[0]));
+
+                  return (
+                    <TouchableOpacity
+                      key={apiType}
+                      style={s.usageApiCard}
+                      onPress={() => setExpandedApi(isExpanded ? null : apiType)}
+                      activeOpacity={0.7}
+                    >
+                      <View style={s.usageApiHeader}>
+                        <Text style={s.usageApiLabel}>{API_LABELS[apiType] ?? apiType.toUpperCase()}</Text>
+                        <Text style={s.usageApiCost}>{formatCost(data.total)} 円</Text>
+                      </View>
+                      {isExpanded && dailySorted.length > 0 && (
+                        <View style={s.usageDailyList}>
+                          {dailySorted.map(([date, info]) => (
+                            <View key={date} style={s.usageDailyRow}>
+                              <Text style={s.usageDailyDate}>{date.slice(5)}</Text>
+                              <Text style={s.usageDailyRequests}>{info.requests}回</Text>
+                              <Text style={s.usageDailyCost}>{formatCost(info.cost)} 円</Text>
+                            </View>
+                          ))}
+                        </View>
+                      )}
+                    </TouchableOpacity>
+                  );
+                })}
+
+                {/* デバイス別 */}
+                {Object.keys(byDevice).length > 0 && (
+                  <>
+                    <Text style={[s.sectionTitle, { marginTop: 16 }]}>デバイス別</Text>
+                    {Object.entries(byDevice).map(([deviceId, info]: [string, any]) => {
+                      const isExpanded = expandedDevice === deviceId;
+                      return (
+                        <TouchableOpacity
+                          key={deviceId}
+                          style={s.usageApiCard}
+                          onPress={() => setExpandedDevice(isExpanded ? null : deviceId)}
+                          activeOpacity={0.7}
+                        >
+                          <View style={s.usageApiHeader}>
+                            <Text style={s.usageApiLabel}>{deviceId === "app" ? "アプリ" : deviceId}</Text>
+                            <Text style={s.usageApiCost}>{formatCost(info.total)} 円</Text>
+                          </View>
+                          {isExpanded && (
+                            <View style={s.usageDailyList}>
+                              {["stt", "llm", "tts"].map((t) =>
+                                info[t] ? (
+                                  <View key={t} style={s.usageDailyRow}>
+                                    <Text style={s.usageDailyDate}>{API_LABELS[t] ?? t}</Text>
+                                    <Text style={s.usageDailyCost}>{formatCost(info[t])} 円</Text>
+                                  </View>
+                                ) : null
+                              )}
+                            </View>
+                          )}
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </>
+                )}
+
+                {/* 為替レート */}
+                {rate && (
+                  <Text style={s.usageRateText}>
+                    適用レート: 1 USD = {rate.rate} 円（{rate.fetched_at?.slice(0, 10)}）
+                  </Text>
+                )}
+
+                {usageData?.total_cost === 0 && (
+                  <Text style={s.emptyText}>この月の利用データはありません</Text>
+                )}
+              </>
+            )}
+          </ScrollView>
+        </Animated.View>
+      </SafeAreaView>
+    );
+  }
 
   // ---- バージョン情報画面 ----
   if (screen === "version") {
@@ -578,7 +761,7 @@ export default function Settings() {
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
 
-          <TouchableOpacity style={s.navRow} onPress={() => {}}>
+          <TouchableOpacity style={s.navRow} onPress={openUsage}>
             <Text style={s.navText}>利用状況</Text>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
@@ -650,4 +833,21 @@ const s = StyleSheet.create({
   buttonDanger:            { backgroundColor: "#ff3b30", padding: 16, borderRadius: 12, alignItems: "center" },
   buttonDisabled:          { backgroundColor: "#999" },
   buttonText:              { color: "#fff", fontSize: 16, fontWeight: "600" },
+  // 利用状況
+  usageMonthRow:           { flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 24, paddingVertical: 8 },
+  usageMonthArrow:         { fontSize: 18, color: "#007AFF", fontWeight: "600", paddingHorizontal: 8 },
+  usageMonthText:          { fontSize: 18, fontWeight: "700", color: "#333" },
+  usageTotalCard:          { backgroundColor: "#f0f7ff", padding: 20, borderRadius: 12, alignItems: "center", borderWidth: 1, borderColor: "#007AFF" },
+  usageTotalLabel:         { fontSize: 14, color: "#666" },
+  usageTotalAmount:        { fontSize: 32, fontWeight: "800", color: "#007AFF", marginTop: 4 },
+  usageApiCard:            { backgroundColor: "#f9f9f9", padding: 14, borderRadius: 10, borderWidth: 1, borderColor: "#e0e0e0" },
+  usageApiHeader:          { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  usageApiLabel:           { fontSize: 15, fontWeight: "600", color: "#333" },
+  usageApiCost:            { fontSize: 15, fontWeight: "700", color: "#007AFF" },
+  usageDailyList:          { marginTop: 10, borderTopWidth: 1, borderTopColor: "#e0e0e0", paddingTop: 8 },
+  usageDailyRow:           { flexDirection: "row", justifyContent: "space-between", alignItems: "center", paddingVertical: 4 },
+  usageDailyDate:          { fontSize: 13, color: "#666", flex: 1 },
+  usageDailyRequests:      { fontSize: 13, color: "#999", marginRight: 12 },
+  usageDailyCost:          { fontSize: 13, fontWeight: "600", color: "#333" },
+  usageRateText:           { fontSize: 12, color: "#999", textAlign: "center", marginTop: 16 },
 });

--- a/app/package.json
+++ b/app/package.json
@@ -40,14 +40,14 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.6",
     "react-native-audio-record": "^0.2.2",
+    "react-native-ble-plx": "^3.2.1",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-sound": "^0.12.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5",
-    "react-native-ble-plx": "^3.2.1"
+    "react-native-webview": "13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -4,7 +4,7 @@
   import OpenAI from "openai";
   import { createHash } from "node:crypto";
   import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-  import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+  import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
 
   const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
   const ddb = DynamoDBDocumentClient.from(ddbClient);
@@ -13,12 +13,121 @@
   const CHARACTERS_TABLE = "toytalker-characters";
   const CHAT_LOGS_TABLE  = "toytalker-chat-logs";
   const LLMS_TABLE       = "toytalker-llms";
+  const USAGE_TABLE         = "toytalker-usage";
+  const UNIT_PRICES_TABLE   = "toytalker-api-unit-prices";
+  const EXCHANGE_RATES_TABLE = "toytalker-exchange-rates";
 
   async function saveLog(item) {
     try {
       await ddb.send(new PutCommand({ TableName: CHAT_LOGS_TABLE, Item: item }));
     } catch (e) {
       console.error("[saveLog] error:", e);
+    }
+  }
+
+  // ---- 単価・マージン・為替レートのキャッシュ ----
+  let cachedPrices = null;
+  let cachedMargin = null;
+  let cachedRates = {};
+  let cacheLoadedAt = 0;
+  const CACHE_TTL_MS = 3600_000;
+
+  async function loadPricingCache() {
+    if (cachedPrices && (Date.now() - cacheLoadedAt) < CACHE_TTL_MS) return;
+    try {
+      const result = await ddb.send(new ScanCommand({
+        TableName: UNIT_PRICES_TABLE,
+        FilterExpression: "version = :v",
+        ExpressionAttributeValues: { ":v": "current" },
+      }));
+      const prices = {};
+      for (const item of (result.Items ?? [])) {
+        const pk = item["provider#api_type"];
+        if (pk === "service#margin") {
+          cachedMargin = Number(item.margin) || 1.5;
+        } else {
+          prices[pk] = item;
+        }
+      }
+      cachedPrices = prices;
+      cacheLoadedAt = Date.now();
+    } catch (e) {
+      console.error("[Pricing] cache load error:", e);
+    }
+  }
+
+  async function getExchangeRate(month, currency = "JPY") {
+    const cacheKey = `${month}#${currency}`;
+    if (cachedRates[cacheKey]) return cachedRates[cacheKey];
+    try {
+      const result = await ddb.send(new GetCommand({
+        TableName: EXCHANGE_RATES_TABLE,
+        Key: { month, currency },
+      }));
+      const rate = Number(result.Item?.rate) || 150;
+      cachedRates[cacheKey] = rate;
+      return rate;
+    } catch (e) {
+      console.error("[ExchangeRate] error:", e);
+      return 150;
+    }
+  }
+
+  function calcCostJpy({ providerApiType, tokensIn, tokensOut, characters, utf8Bytes, mora, pcmBytes, userMessageChars, usdJpyRate }) {
+    const price = cachedPrices?.[providerApiType];
+    if (!price) return null;
+    const margin = cachedMargin || 1.5;
+    if (price.currency === "JPY") {
+      const inputCost = (mora ?? 0) * Number(price.unit_price_input);
+      return { costJpy: inputCost * margin, usdJpyRate: null, unitPriceUsd: null, margin };
+    }
+    const inputUnit = price.input_unit_type;
+    const outputUnit = price.output_unit_type;
+    let costUsd = 0;
+    if (inputUnit === "tokens") {
+      costUsd += (tokensIn ?? 0) * Number(price.unit_price_input);
+      if (outputUnit === "tokens" || outputUnit === "audio_tokens") {
+        costUsd += (tokensOut ?? 0) * Number(price.unit_price_output);
+      }
+    } else if (inputUnit === "characters") {
+      costUsd += (characters ?? 0) * Number(price.unit_price_input);
+      if (outputUnit === "audio_tokens" && pcmBytes) {
+        const durationSec = pcmBytes / (24000 * 2);
+        const audioTokens = Math.round((durationSec / 60) * 800);
+        costUsd += audioTokens * Number(price.unit_price_output);
+      }
+    } else if (inputUnit === "utf8_bytes") {
+      costUsd += (utf8Bytes ?? 0) * Number(price.unit_price_input);
+    } else if (inputUnit === "audio_tokens") {
+      const chars = userMessageChars ?? 0;
+      const textTokens = Math.round(chars * 0.3);
+      const speechSec = chars / 6;
+      const audioTokens = Math.round(speechSec * (30000 / 3600));
+      costUsd += audioTokens * Number(price.unit_price_input);
+      costUsd += textTokens * Number(price.unit_price_output);
+    }
+    const costJpy = costUsd * usdJpyRate * margin;
+    return { costJpy, usdJpyRate, unitPriceUsd: Number(price.unit_price_input), margin };
+  }
+
+  async function addUsage({ ownerId, deviceId, date, apiType, provider, model, costJpy, tokensIn, tokensOut, ttsCharacters, sttCharacters, usdJpyRate, unitPriceUsd, margin }) {
+    if (!costJpy || costJpy <= 0) return;
+    const sk = `${date}#${deviceId}#${apiType}`;
+    try {
+      const addParts = ["cost_jpy :cost", "requests :one"];
+      const vals = { ":cost": costJpy, ":one": 1, ":p": provider, ":m": model, ":r": usdJpyRate ?? 0, ":u": unitPriceUsd ?? 0, ":mg": margin };
+      if (tokensIn)      { addParts.push("tokens_in :tin");       vals[":tin"]  = tokensIn; }
+      if (tokensOut)     { addParts.push("tokens_out :tout");     vals[":tout"] = tokensOut; }
+      if (ttsCharacters) { addParts.push("tts_characters :ttsc"); vals[":ttsc"] = ttsCharacters; }
+      if (sttCharacters) { addParts.push("stt_characters :sttc"); vals[":sttc"] = sttCharacters; }
+      await ddb.send(new UpdateCommand({
+        TableName: USAGE_TABLE,
+        Key: { owner_id: ownerId, "date#device_id#api_type": sk },
+        UpdateExpression: `ADD ${addParts.join(", ")} SET provider = :p, model = :m, usd_jpy_rate = :r, unit_price_usd = :u, margin = :mg`,
+        ExpressionAttributeValues: vals,
+      }));
+    } catch (e) {
+      console.error("[addUsage] error:", e);
     }
   }
 
@@ -366,6 +475,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         vendorId: voiceRes.Item.vendor_id,
         personalityPrompt,
         ownerId: device.owner_id ?? null,
+        characterId: device.character_id ?? "default",
         llmProvider,
         llmModelId,
       };
@@ -406,6 +516,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
     let personalityPrompt = null;
     let llmProvider = LLM_DEFAULT_PROVIDER;
     let llmModelId  = LLM_DEFAULT_MODEL;
+    let characterId = "default";
 
     if (deviceId) {
       const charConfig = await resolveCharacterFromDynamo(deviceId);
@@ -415,6 +526,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         personalityPrompt = charConfig.personalityPrompt;
         llmProvider = charConfig.llmProvider;
         llmModelId  = charConfig.llmModelId;
+        characterId = charConfig.characterId ?? "default";
         if (charConfig.ownerId) ownerId = charConfig.ownerId;
         console.log(`[DynamoDB] device=${deviceId}, tts=${charConfig.provider}, voice=${charConfig.vendorId}, llm=${llmProvider}/${llmModelId}, hasPersonality=${!!personalityPrompt}, ownerId=${ownerId}`);
       } else {
@@ -700,9 +812,47 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       }
       sendMeta(res, "done", {});
 
-      // ---- アシスタントログ保存 ----
+      // ---- コスト計算 + usage書き込み + ログ保存 ----
       if (sessionId !== "unknown" && textAll.trim()) {
         const assistantTimestamp = new Date().toISOString();
+
+        await loadPricingCache();
+        const date = assistantTimestamp.slice(0, 10);
+        const month = assistantTimestamp.slice(0, 7);
+        const usdJpyRate = await getExchangeRate(month);
+
+        // LLM
+        const llmPriceKey = `${llmProvider}#llm`;
+        const llmCost = calcCostJpy({ providerApiType: llmPriceKey, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate });
+        if (llmCost) {
+          addUsage({ ownerId, deviceId, date, apiType: "llm", provider: llmProvider, model: llmModelId, costJpy: llmCost.costJpy, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate: llmCost.usdJpyRate, unitPriceUsd: llmCost.unitPriceUsd, margin: llmCost.margin });
+        }
+
+        // TTS
+        const ttsPriceKey = `${cfg.ttsVendor}#tts`;
+        let ttsCostResult;
+        if (cfg.ttsVendor === "sakura") {
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, mora: ttsInputChars, usdJpyRate });
+        } else if (cfg.ttsVendor === "fishaudio") {
+          const utf8Bytes = Buffer.byteLength(textAll.trim(), "utf8");
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, utf8Bytes, usdJpyRate });
+        } else {
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, characters: ttsInputChars, usdJpyRate });
+        }
+        if (ttsCostResult) {
+          addUsage({ ownerId, deviceId, date, apiType: "tts", provider: cfg.ttsVendor, model: cfg.ttsModel, costJpy: ttsCostResult.costJpy, ttsCharacters: ttsInputChars, usdJpyRate: ttsCostResult.usdJpyRate, unitPriceUsd: ttsCostResult.unitPriceUsd, margin: ttsCostResult.margin });
+        }
+
+        // STT (確定文の文字数から概算)
+        const userMsgChars = lastUserMsg?.content?.length ?? 0;
+        let sttCost = null;
+        if (userMsgChars > 0) {
+          sttCost = calcCostJpy({ providerApiType: "soniox#stt", userMessageChars: userMsgChars, usdJpyRate });
+          if (sttCost) {
+            addUsage({ ownerId, deviceId, date, apiType: "stt", provider: "soniox", model: "soniox", costJpy: sttCost.costJpy, sttCharacters: userMsgChars, usdJpyRate: sttCost.usdJpyRate, unitPriceUsd: sttCost.unitPriceUsd, margin: sttCost.margin });
+          }
+        }
+
         saveLog({
           "owner_id#device_id":   `owner_id#${ownerId}#device_id#${deviceId}`,
           "session_id#timestamp": `session_id#${sessionId}#timestamp#${assistantTimestamp}`,
@@ -714,8 +864,12 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
           tts_provider: cfg.ttsVendor, tts_input_units: ttsInputChars, tts_input_unit_type: "characters",
           stt_provider: "soniox", stt_input_units: null, stt_input_unit_type: null,
           duration_ms: Date.now() - requestAt,
-          character_id: null,
+          character_id: characterId,
           voice_id: voice,
+          cost_stt: sttCost?.costJpy ?? 0,
+          cost_llm: llmCost?.costJpy ?? 0,
+          cost_tts: ttsCostResult?.costJpy ?? 0,
+          cost_total: (sttCost?.costJpy ?? 0) + (llmCost?.costJpy ?? 0) + (ttsCostResult?.costJpy ?? 0),
         });
       }
     } catch (err) {

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -825,7 +825,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         const llmPriceKey = `${llmProvider}#llm`;
         const llmCost = calcCostJpy({ providerApiType: llmPriceKey, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate });
         if (llmCost) {
-          addUsage({ ownerId, deviceId, date, apiType: "llm", provider: llmProvider, model: llmModelId, costJpy: llmCost.costJpy, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate: llmCost.usdJpyRate, unitPriceUsd: llmCost.unitPriceUsd, margin: llmCost.margin });
+          await addUsage({ ownerId, deviceId, date, apiType: "llm", provider: llmProvider, model: llmModelId, costJpy: llmCost.costJpy, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate: llmCost.usdJpyRate, unitPriceUsd: llmCost.unitPriceUsd, margin: llmCost.margin });
         }
 
         // TTS
@@ -840,7 +840,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
           ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, characters: ttsInputChars, usdJpyRate });
         }
         if (ttsCostResult) {
-          addUsage({ ownerId, deviceId, date, apiType: "tts", provider: cfg.ttsVendor, model: cfg.ttsModel, costJpy: ttsCostResult.costJpy, ttsCharacters: ttsInputChars, usdJpyRate: ttsCostResult.usdJpyRate, unitPriceUsd: ttsCostResult.unitPriceUsd, margin: ttsCostResult.margin });
+          await addUsage({ ownerId, deviceId, date, apiType: "tts", provider: cfg.ttsVendor, model: cfg.ttsModel, costJpy: ttsCostResult.costJpy, ttsCharacters: ttsInputChars, usdJpyRate: ttsCostResult.usdJpyRate, unitPriceUsd: ttsCostResult.unitPriceUsd, margin: ttsCostResult.margin });
         }
 
         // STT (確定文の文字数から概算)
@@ -849,11 +849,11 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         if (userMsgChars > 0) {
           sttCost = calcCostJpy({ providerApiType: "soniox#stt", userMessageChars: userMsgChars, usdJpyRate });
           if (sttCost) {
-            addUsage({ ownerId, deviceId, date, apiType: "stt", provider: "soniox", model: "soniox", costJpy: sttCost.costJpy, sttCharacters: userMsgChars, usdJpyRate: sttCost.usdJpyRate, unitPriceUsd: sttCost.unitPriceUsd, margin: sttCost.margin });
+            await addUsage({ ownerId, deviceId, date, apiType: "stt", provider: "soniox", model: "soniox", costJpy: sttCost.costJpy, sttCharacters: userMsgChars, usdJpyRate: sttCost.usdJpyRate, unitPriceUsd: sttCost.unitPriceUsd, margin: sttCost.margin });
           }
         }
 
-        saveLog({
+        await saveLog({
           "owner_id#device_id":   `owner_id#${ownerId}#device_id#${deviceId}`,
           "session_id#timestamp": `session_id#${sessionId}#timestamp#${assistantTimestamp}`,
           owner_id: ownerId, device_id: deviceId, source: "esp",

--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -845,38 +845,23 @@
       }
       send(res, "done", {});
 
-      // ---- アシスタントログ保存 ----
+      // ---- コスト計算 + usage書き込み + ログ保存 ----
       if (sessionId !== "unknown" && textAll.trim()) {
         const assistantTimestamp = new Date().toISOString();
-        saveLog({
-          "owner_id#device_id":   `owner_id#${ownerId}#device_id#${deviceId}`,
-          "session_id#timestamp": `session_id#${sessionId}#timestamp#${assistantTimestamp}`,
-          owner_id: ownerId, device_id: deviceId, source: "app",
-          role: "assistant", content: textAll.trim(),
-          content_type: "text", timestamp: assistantTimestamp, session_id: sessionId,
-          llm_provider: llmProvider, llm_model: llmModelId,
-          llm_tokens_in: llmTokensIn, llm_tokens_out: llmTokensOut,
-          tts_provider: cfg.ttsVendor, tts_input_units: ttsInputChars, tts_input_unit_type: "characters",
-          stt_provider: null, stt_input_units: null, stt_input_unit_type: null,
-          duration_ms: Date.now() - requestAt,
-          character_id: characterId ?? "default",
-          voice_id: voice,
-        });
 
-        // ---- usage書き込み ----
         await loadPricingCache();
-        const date = assistantTimestamp.slice(0, 10); // "2026-04-19"
-        const month = assistantTimestamp.slice(0, 7);  // "2026-04"
+        const date = assistantTimestamp.slice(0, 10);
+        const month = assistantTimestamp.slice(0, 7);
         const usdJpyRate = await getExchangeRate(month);
 
-        // LLM usage
+        // LLM
         const llmPriceKey = `${llmProvider}#llm`;
         const llmCost = calcCostJpy({ providerApiType: llmPriceKey, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate });
         if (llmCost) {
           addUsage({ ownerId, deviceId, date, apiType: "llm", provider: llmProvider, model: llmModelId, costJpy: llmCost.costJpy, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate: llmCost.usdJpyRate, unitPriceUsd: llmCost.unitPriceUsd, margin: llmCost.margin });
         }
 
-        // TTS usage
+        // TTS
         const ttsPriceKey = `${cfg.ttsVendor}#tts`;
         let ttsCostResult;
         if (cfg.ttsVendor === "gemini") {
@@ -896,14 +881,35 @@
           addUsage({ ownerId, deviceId, date, apiType: "tts", provider: cfg.ttsVendor, model: cfg.ttsModel, costJpy: ttsCostResult.costJpy, ttsCharacters: ttsInputChars, usdJpyRate: ttsCostResult.usdJpyRate, unitPriceUsd: ttsCostResult.unitPriceUsd, margin: ttsCostResult.margin });
         }
 
-        // STT usage (確定文の文字数から概算)
+        // STT (確定文の文字数から概算)
         const userMsgChars = lastUserMsg?.content?.length ?? 0;
+        let sttCost = null;
         if (userMsgChars > 0) {
-          const sttCost = calcCostJpy({ providerApiType: "soniox#stt", userMessageChars: userMsgChars, usdJpyRate });
+          sttCost = calcCostJpy({ providerApiType: "soniox#stt", userMessageChars: userMsgChars, usdJpyRate });
           if (sttCost) {
             addUsage({ ownerId, deviceId, date, apiType: "stt", provider: "soniox", model: "soniox", costJpy: sttCost.costJpy, sttCharacters: userMsgChars, usdJpyRate: sttCost.usdJpyRate, unitPriceUsd: sttCost.unitPriceUsd, margin: sttCost.margin });
           }
         }
+
+        // ログ保存（計算済みコスト付き）
+        saveLog({
+          "owner_id#device_id":   `owner_id#${ownerId}#device_id#${deviceId}`,
+          "session_id#timestamp": `session_id#${sessionId}#timestamp#${assistantTimestamp}`,
+          owner_id: ownerId, device_id: deviceId, source: "app",
+          role: "assistant", content: textAll.trim(),
+          content_type: "text", timestamp: assistantTimestamp, session_id: sessionId,
+          llm_provider: llmProvider, llm_model: llmModelId,
+          llm_tokens_in: llmTokensIn, llm_tokens_out: llmTokensOut,
+          tts_provider: cfg.ttsVendor, tts_input_units: ttsInputChars, tts_input_unit_type: "characters",
+          stt_provider: null, stt_input_units: null, stt_input_unit_type: null,
+          duration_ms: Date.now() - requestAt,
+          character_id: characterId ?? "default",
+          voice_id: voice,
+          cost_stt: sttCost?.costJpy ?? 0,
+          cost_llm: llmCost?.costJpy ?? 0,
+          cost_tts: ttsCostResult?.costJpy ?? 0,
+          cost_total: (sttCost?.costJpy ?? 0) + (llmCost?.costJpy ?? 0) + (ttsCostResult?.costJpy ?? 0),
+        });
       }
     } catch (err) {
       const msg = (err && err.message) ? err.message : String(err);

--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -4,20 +4,140 @@
   import OpenAI from "openai";
   import { createHash } from "node:crypto";
   import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-  import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+  import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, QueryCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
 
   const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
   const ddb = DynamoDBDocumentClient.from(ddbClient);
-  const CHARACTERS_TABLE = "toytalker-characters";
-  const VOICES_TABLE     = "toytalker-voices";
-  const CHAT_LOGS_TABLE  = "toytalker-chat-logs";
-  const LLMS_TABLE       = "toytalker-llms";
+  const CHARACTERS_TABLE    = "toytalker-characters";
+  const VOICES_TABLE        = "toytalker-voices";
+  const CHAT_LOGS_TABLE     = "toytalker-chat-logs";
+  const LLMS_TABLE          = "toytalker-llms";
+  const USAGE_TABLE         = "toytalker-usage";
+  const UNIT_PRICES_TABLE   = "toytalker-api-unit-prices";
+  const EXCHANGE_RATES_TABLE = "toytalker-exchange-rates";
 
   async function saveLog(item) {
     try {
       await ddb.send(new PutCommand({ TableName: CHAT_LOGS_TABLE, Item: item }));
     } catch (e) {
       console.error("[saveLog] error:", e);
+    }
+  }
+
+  // ---- 単価・マージン・為替レートのキャッシュ ----
+  let cachedPrices = null;   // { "openai#llm": {...}, "openai#tts": {...}, ... }
+  let cachedMargin = null;   // number
+  let cachedRates = {};      // { "2026-04#JPY": 150, ... }
+  let cacheLoadedAt = 0;
+  const CACHE_TTL_MS = 3600_000; // 1時間
+
+  async function loadPricingCache() {
+    if (cachedPrices && (Date.now() - cacheLoadedAt) < CACHE_TTL_MS) return;
+    try {
+      const result = await ddb.send(new ScanCommand({
+        TableName: UNIT_PRICES_TABLE,
+        FilterExpression: "version = :v",
+        ExpressionAttributeValues: { ":v": "current" },
+      }));
+      const prices = {};
+      for (const item of (result.Items ?? [])) {
+        const pk = item["provider#api_type"];
+        if (pk === "service#margin") {
+          cachedMargin = Number(item.margin) || 1.5;
+        } else {
+          prices[pk] = item;
+        }
+      }
+      cachedPrices = prices;
+      cacheLoadedAt = Date.now();
+      console.log(`[Pricing] cached ${Object.keys(prices).length} prices, margin=${cachedMargin}`);
+    } catch (e) {
+      console.error("[Pricing] cache load error:", e);
+    }
+  }
+
+  async function getExchangeRate(month, currency = "JPY") {
+    const cacheKey = `${month}#${currency}`;
+    if (cachedRates[cacheKey]) return cachedRates[cacheKey];
+    try {
+      const result = await ddb.send(new GetCommand({
+        TableName: EXCHANGE_RATES_TABLE,
+        Key: { month, currency },
+      }));
+      const rate = Number(result.Item?.rate) || 150;
+      cachedRates[cacheKey] = rate;
+      return rate;
+    } catch (e) {
+      console.error("[ExchangeRate] error:", e);
+      return 150;
+    }
+  }
+
+  function calcCostJpy({ providerApiType, tokensIn, tokensOut, characters, utf8Bytes, mora, pcmBytes, userMessageChars, usdJpyRate }) {
+    const price = cachedPrices?.[providerApiType];
+    if (!price) return null;
+    const margin = cachedMargin || 1.5;
+
+    // Sakura: 円建て直接
+    if (price.currency === "JPY") {
+      const inputCost = (mora ?? 0) * Number(price.unit_price_input);
+      return { costJpy: inputCost * margin, usdJpyRate: null, unitPriceUsd: null, margin };
+    }
+
+    const inputUnit = price.input_unit_type;
+    const outputUnit = price.output_unit_type;
+    let costUsd = 0;
+
+    if (inputUnit === "tokens") {
+      costUsd += (tokensIn ?? 0) * Number(price.unit_price_input);
+      if (outputUnit === "tokens") {
+        costUsd += (tokensOut ?? 0) * Number(price.unit_price_output);
+      } else if (outputUnit === "audio_tokens") {
+        costUsd += (tokensOut ?? 0) * Number(price.unit_price_output);
+      }
+    } else if (inputUnit === "characters") {
+      costUsd += (characters ?? 0) * Number(price.unit_price_input);
+      if (outputUnit === "audio_tokens" && pcmBytes) {
+        // OpenAI TTS: PCMバイト数から音声秒数→音声トークン数を概算
+        const durationSec = pcmBytes / (24000 * 2);
+        const audioTokens = Math.round((durationSec / 60) * 800);
+        costUsd += audioTokens * Number(price.unit_price_output);
+      }
+    } else if (inputUnit === "utf8_bytes") {
+      costUsd += (utf8Bytes ?? 0) * Number(price.unit_price_input);
+    } else if (inputUnit === "audio_tokens") {
+      // STT: 確定文の文字数から概算
+      const chars = userMessageChars ?? 0;
+      const textTokens = Math.round(chars * 0.3);
+      const speechSec = chars / 6;
+      const audioTokens = Math.round(speechSec * (30000 / 3600));
+      costUsd += audioTokens * Number(price.unit_price_input);
+      costUsd += textTokens * Number(price.unit_price_output);
+    }
+
+    const costJpy = costUsd * usdJpyRate * margin;
+    return { costJpy, usdJpyRate, unitPriceUsd: Number(price.unit_price_input), margin };
+  }
+
+  async function addUsage({ ownerId, deviceId, date, apiType, provider, model, costJpy, tokensIn, tokensOut, ttsCharacters, sttCharacters, usdJpyRate, unitPriceUsd, margin }) {
+    if (!costJpy || costJpy <= 0) return;
+    const sk = `${date}#${deviceId}#${apiType}`;
+    try {
+      const addParts = ["cost_jpy :cost", "requests :one"];
+      const vals = { ":cost": costJpy, ":one": 1, ":p": provider, ":m": model, ":r": usdJpyRate ?? 0, ":u": unitPriceUsd ?? 0, ":mg": margin };
+      if (tokensIn)      { addParts.push("tokens_in :tin");       vals[":tin"]  = tokensIn; }
+      if (tokensOut)     { addParts.push("tokens_out :tout");     vals[":tout"] = tokensOut; }
+      if (ttsCharacters) { addParts.push("tts_characters :ttsc"); vals[":ttsc"] = ttsCharacters; }
+      if (sttCharacters) { addParts.push("stt_characters :sttc"); vals[":sttc"] = sttCharacters; }
+
+      await ddb.send(new UpdateCommand({
+        TableName: USAGE_TABLE,
+        Key: { owner_id: ownerId, "date#device_id#api_type": sk },
+        UpdateExpression: `ADD ${addParts.join(", ")} SET provider = :p, model = :m, usd_jpy_rate = :r, unit_price_usd = :u, margin = :mg`,
+        ExpressionAttributeValues: vals,
+      }));
+    } catch (e) {
+      console.error("[addUsage] error:", e);
     }
   }
 
@@ -205,11 +325,10 @@
     return { model: cfg.ttsModel, voiceName };
   }
 
-  // Gemini Speech Generation → base64(WAV)（APIキーは GOOGLE_API_KEY を共用）
+  // Gemini Speech Generation → { b64, audioTokens } （APIキーは GOOGLE_API_KEY を共用）
   async function ttsToBase64Gemini(text, { model = "gemini-2.5-flash-preview-tts", voiceName = "Kore" } = {}) {
     const key = process.env.GOOGLE_API_KEY;
     if (!key) throw new Error("GOOGLE_API_KEY is not set");
-    // Gemini TTSはテキスト生成を防ぐため、明示的に読み上げ指示を付ける
     const ttsPrompt = `Read the following text aloud: ${text}`;
 
     const maxRetries = 2;
@@ -233,10 +352,9 @@
       if (!resp.ok) throw new Error(json?.error?.message || "Gemini TTS failed");
       const b64Pcm = json?.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data || "";
       if (b64Pcm) {
-        // 24kHz/mono PCM16 → 既存の WAV ラッパで包む
-        return pcm16ToWavBase64(b64Pcm, 24000, 1);
+        const audioTokens = json?.usageMetadata?.candidatesTokenCount ?? 0;
+        return { b64: pcm16ToWavBase64(b64Pcm, 24000, 1), audioTokens };
       }
-      // empty audio の場合はリトライ
       console.log(`[Gemini TTS] empty audio, retry ${attempt + 1}/${maxRetries + 1}`);
     }
     throw new Error("Gemini TTS: empty audio after retries");
@@ -416,6 +534,9 @@
     const requestAt  = Date.now();
     const userTimestamp = new Date(requestAt).toISOString();
 
+    // 単価キャッシュを先にロード（await不要、バックグラウンドで）
+    loadPricingCache();
+
     const characterId = typeof body.character_id === "string" ? body.character_id : null;
     if (characterId && characterId !== "default") {
       const charConfig = await resolveCharacterFromDynamo(characterId);
@@ -483,6 +604,8 @@
     let firstTtsMarked = false;
     let llmTokensIn = 0, llmTokensOut = 0;
     let ttsInputChars = 0;
+    let ttsPcmBytes = 0;
+    let geminiTtsAudioTokens = 0;
 
     // ---- LLM ストリーム生成 ----
     function streamLLMOpenAI(msgs, model) {
@@ -656,6 +779,8 @@
         let b64, fmt;
         if (cfg.ttsVendor === "openai") {
           b64 = await ttsToBase64OpenAI(t, voice, cfg.ttsModel);
+          // PCMバイト数を概算（WAV base64からヘッダ44バイト分を除く）
+          ttsPcmBytes += Math.round(b64.length * 3 / 4) - 44;
           fmt = "wav";
         } else if (cfg.ttsVendor === "google") {
           const g = resolveGoogleTtsFromBody(body);
@@ -666,7 +791,9 @@
         } else if (cfg.ttsVendor === "gemini") {
           const g = resolveGeminiTtsFromBody(body, cfg);
           if (voice) g.voiceName = voice;
-          b64 = await ttsToBase64Gemini(t, g);
+          const result = await ttsToBase64Gemini(t, g);
+          b64 = result.b64;
+          geminiTtsAudioTokens += result.audioTokens;
           fmt = "wav";
         } else if (cfg.ttsVendor === "elevenlabs") {
           const e = resolveElevenLabsTtsFromBody(body, cfg);
@@ -735,6 +862,48 @@
           character_id: characterId ?? "default",
           voice_id: voice,
         });
+
+        // ---- usage書き込み ----
+        await loadPricingCache();
+        const date = assistantTimestamp.slice(0, 10); // "2026-04-19"
+        const month = assistantTimestamp.slice(0, 7);  // "2026-04"
+        const usdJpyRate = await getExchangeRate(month);
+
+        // LLM usage
+        const llmPriceKey = `${llmProvider}#llm`;
+        const llmCost = calcCostJpy({ providerApiType: llmPriceKey, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate });
+        if (llmCost) {
+          addUsage({ ownerId, deviceId, date, apiType: "llm", provider: llmProvider, model: llmModelId, costJpy: llmCost.costJpy, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate: llmCost.usdJpyRate, unitPriceUsd: llmCost.unitPriceUsd, margin: llmCost.margin });
+        }
+
+        // TTS usage
+        const ttsPriceKey = `${cfg.ttsVendor}#tts`;
+        let ttsCostResult;
+        if (cfg.ttsVendor === "gemini") {
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, tokensIn: ttsInputChars, tokensOut: geminiTtsAudioTokens, usdJpyRate });
+        } else if (cfg.ttsVendor === "openai") {
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, characters: ttsInputChars, pcmBytes: ttsPcmBytes, usdJpyRate });
+        } else if (cfg.ttsVendor === "fishaudio") {
+          const utf8Bytes = Buffer.byteLength(textAll.trim(), "utf8");
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, utf8Bytes, usdJpyRate });
+        } else if (cfg.ttsVendor === "sakura") {
+          const mora = ttsInputChars;
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, mora, usdJpyRate });
+        } else {
+          ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, characters: ttsInputChars, usdJpyRate });
+        }
+        if (ttsCostResult) {
+          addUsage({ ownerId, deviceId, date, apiType: "tts", provider: cfg.ttsVendor, model: cfg.ttsModel, costJpy: ttsCostResult.costJpy, ttsCharacters: ttsInputChars, usdJpyRate: ttsCostResult.usdJpyRate, unitPriceUsd: ttsCostResult.unitPriceUsd, margin: ttsCostResult.margin });
+        }
+
+        // STT usage (確定文の文字数から概算)
+        const userMsgChars = lastUserMsg?.content?.length ?? 0;
+        if (userMsgChars > 0) {
+          const sttCost = calcCostJpy({ providerApiType: "soniox#stt", userMessageChars: userMsgChars, usdJpyRate });
+          if (sttCost) {
+            addUsage({ ownerId, deviceId, date, apiType: "stt", provider: "soniox", model: "soniox", costJpy: sttCost.costJpy, sttCharacters: userMsgChars, usdJpyRate: sttCost.usdJpyRate, unitPriceUsd: sttCost.unitPriceUsd, margin: sttCost.margin });
+          }
+        }
       }
     } catch (err) {
       const msg = (err && err.message) ? err.message : String(err);

--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -858,7 +858,7 @@
         const llmPriceKey = `${llmProvider}#llm`;
         const llmCost = calcCostJpy({ providerApiType: llmPriceKey, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate });
         if (llmCost) {
-          addUsage({ ownerId, deviceId, date, apiType: "llm", provider: llmProvider, model: llmModelId, costJpy: llmCost.costJpy, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate: llmCost.usdJpyRate, unitPriceUsd: llmCost.unitPriceUsd, margin: llmCost.margin });
+          await addUsage({ ownerId, deviceId, date, apiType: "llm", provider: llmProvider, model: llmModelId, costJpy: llmCost.costJpy, tokensIn: llmTokensIn, tokensOut: llmTokensOut, usdJpyRate: llmCost.usdJpyRate, unitPriceUsd: llmCost.unitPriceUsd, margin: llmCost.margin });
         }
 
         // TTS
@@ -878,7 +878,7 @@
           ttsCostResult = calcCostJpy({ providerApiType: ttsPriceKey, characters: ttsInputChars, usdJpyRate });
         }
         if (ttsCostResult) {
-          addUsage({ ownerId, deviceId, date, apiType: "tts", provider: cfg.ttsVendor, model: cfg.ttsModel, costJpy: ttsCostResult.costJpy, ttsCharacters: ttsInputChars, usdJpyRate: ttsCostResult.usdJpyRate, unitPriceUsd: ttsCostResult.unitPriceUsd, margin: ttsCostResult.margin });
+          await addUsage({ ownerId, deviceId, date, apiType: "tts", provider: cfg.ttsVendor, model: cfg.ttsModel, costJpy: ttsCostResult.costJpy, ttsCharacters: ttsInputChars, usdJpyRate: ttsCostResult.usdJpyRate, unitPriceUsd: ttsCostResult.unitPriceUsd, margin: ttsCostResult.margin });
         }
 
         // STT (確定文の文字数から概算)
@@ -887,12 +887,12 @@
         if (userMsgChars > 0) {
           sttCost = calcCostJpy({ providerApiType: "soniox#stt", userMessageChars: userMsgChars, usdJpyRate });
           if (sttCost) {
-            addUsage({ ownerId, deviceId, date, apiType: "stt", provider: "soniox", model: "soniox", costJpy: sttCost.costJpy, sttCharacters: userMsgChars, usdJpyRate: sttCost.usdJpyRate, unitPriceUsd: sttCost.unitPriceUsd, margin: sttCost.margin });
+            await addUsage({ ownerId, deviceId, date, apiType: "stt", provider: "soniox", model: "soniox", costJpy: sttCost.costJpy, sttCharacters: userMsgChars, usdJpyRate: sttCost.usdJpyRate, unitPriceUsd: sttCost.unitPriceUsd, margin: sttCost.margin });
           }
         }
 
         // ログ保存（計算済みコスト付き）
-        saveLog({
+        await saveLog({
           "owner_id#device_id":   `owner_id#${ownerId}#device_id#${deviceId}`,
           "session_id#timestamp": `session_id#${sessionId}#timestamp#${assistantTimestamp}`,
           owner_id: ownerId, device_id: deviceId, source: "app",

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -8,11 +8,13 @@ const client = new DynamoDBClient({ region: "ap-northeast-1" });
 const ddb = DynamoDBDocumentClient.from(client);
 
 // ---- テーブル定義 ----
-const DEVICES_TABLE    = "toytalker-devices";
-const VOICES_TABLE     = "toytalker-voices";
-const CHARACTERS_TABLE = "toytalker-characters";
-const CHAT_LOGS_TABLE  = "toytalker-chat-logs";
-const LLMS_TABLE       = "toytalker-llms";
+const DEVICES_TABLE        = "toytalker-devices";
+const VOICES_TABLE         = "toytalker-voices";
+const CHARACTERS_TABLE     = "toytalker-characters";
+const CHAT_LOGS_TABLE      = "toytalker-chat-logs";
+const LLMS_TABLE           = "toytalker-llms";
+const USAGE_TABLE          = "toytalker-usage";
+const EXCHANGE_RATES_TABLE = "toytalker-exchange-rates";
 
 const response = (statusCode, body) => ({
   statusCode,
@@ -278,6 +280,74 @@ export const handler = async (event) => {
         ScanIndexForward: true,
       }));
       return response(200, { messages: result.Items ?? [] });
+    }
+
+    // ---- GET /usage ---- 月次利用状況取得
+    if (method === "GET" && path === "/usage") {
+      const ownerId = event.queryStringParameters?.owner_id ?? "user_123";
+      const month   = event.queryStringParameters?.month ?? new Date().toISOString().slice(0, 7);
+
+      // usageテーブルから該当月のレコードを取得
+      const result = await ddb.send(new QueryCommand({
+        TableName: USAGE_TABLE,
+        KeyConditionExpression: "owner_id = :oid AND begins_with(#sk, :monthPrefix)",
+        ExpressionAttributeNames: { "#sk": "date#device_id#api_type" },
+        ExpressionAttributeValues: { ":oid": ownerId, ":monthPrefix": month },
+      }));
+
+      const items = result.Items ?? [];
+
+      // 集計
+      let totalCost = 0;
+      const byApiType = {};   // { llm: { total: 0, daily: [...] }, tts: {...}, stt: {...} }
+      const byDevice = {};    // { device_abc: { total: 0, llm: 0, tts: 0, stt: 0 }, ... }
+
+      for (const item of items) {
+        const sk = item["date#device_id#api_type"] ?? "";
+        const parts = sk.split("#");
+        const date = parts[0] ?? "";
+        const deviceId = parts[1] ?? "";
+        const apiType = parts[2] ?? "";
+        const cost = Number(item.cost_jpy) || 0;
+
+        totalCost += cost;
+
+        // API種別ごと
+        if (!byApiType[apiType]) byApiType[apiType] = { total: 0, daily: [] };
+        byApiType[apiType].total += cost;
+        byApiType[apiType].daily.push({
+          date, device_id: deviceId, cost,
+          provider: item.provider, model: item.model,
+          tokens_in: item.tokens_in, tokens_out: item.tokens_out,
+          tts_characters: item.tts_characters, stt_characters: item.stt_characters,
+          requests: item.requests,
+        });
+
+        // デバイスごと
+        if (!byDevice[deviceId]) byDevice[deviceId] = { total: 0 };
+        byDevice[deviceId].total += cost;
+        byDevice[deviceId][apiType] = (byDevice[deviceId][apiType] ?? 0) + cost;
+      }
+
+      // 為替レート
+      let exchangeRate = null;
+      try {
+        const rateResult = await ddb.send(new GetCommand({
+          TableName: EXCHANGE_RATES_TABLE,
+          Key: { month, currency: "JPY" },
+        }));
+        exchangeRate = rateResult.Item ?? null;
+      } catch (e) {
+        console.error("[ExchangeRate] error:", e);
+      }
+
+      return response(200, {
+        month,
+        total_cost: Math.round(totalCost * 1000) / 1000,
+        by_api_type: byApiType,
+        by_device: byDevice,
+        exchange_rate: exchangeRate,
+      });
     }
 
     return response(404, { error: "Not found" });

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -435,21 +435,43 @@ export const handler = async (event) => {
     // ---- GET /usage/detail ---- 日次詳細（会話ごとのコスト）
     if (method === "GET" && path === "/usage/detail") {
       const ownerId  = event.queryStringParameters?.owner_id  ?? "user_123";
-      const deviceId = event.queryStringParameters?.device_id ?? "app";
+      const deviceId = event.queryStringParameters?.device_id;
       const date     = event.queryStringParameters?.date;
       if (!date) return response(400, { error: "date is required" });
 
-      const pk = `owner_id#${ownerId}#device_id#${deviceId}`;
-      const result = await ddb.send(new QueryCommand({
-        TableName: CHAT_LOGS_TABLE,
-        KeyConditionExpression: "#pk = :pk",
-        ExpressionAttributeNames: { "#pk": "owner_id#device_id" },
-        ExpressionAttributeValues: { ":pk": pk },
-        ScanIndexForward: true,
-      }));
+      // device_id指定あり→そのデバイスのみ、省略→全デバイス
+      let deviceIds = deviceId ? [deviceId] : [];
+      if (!deviceId) {
+        const usageResult = await ddb.send(new QueryCommand({
+          TableName: USAGE_TABLE,
+          KeyConditionExpression: "owner_id = :oid AND begins_with(#sk, :datePrefix)",
+          ExpressionAttributeNames: { "#sk": "date#device_id#api_type" },
+          ExpressionAttributeValues: { ":oid": ownerId, ":datePrefix": date },
+        }));
+        const devSet = new Set();
+        for (const item of (usageResult.Items ?? [])) {
+          const parts = (item["date#device_id#api_type"] ?? "").split("#");
+          if (parts[1]) devSet.add(parts[1]);
+        }
+        deviceIds = devSet.size > 0 ? [...devSet] : ["app"];
+      }
 
-      // 該当日のログだけフィルタ
-      const dayItems = (result.Items ?? []).filter(item => item.timestamp?.startsWith(date));
+      const allItems = [];
+      for (const did of deviceIds) {
+        const pk = `owner_id#${ownerId}#device_id#${did}`;
+        const result = await ddb.send(new QueryCommand({
+          TableName: CHAT_LOGS_TABLE,
+          KeyConditionExpression: "#pk = :pk",
+          ExpressionAttributeNames: { "#pk": "owner_id#device_id" },
+          ExpressionAttributeValues: { ":pk": pk },
+          ScanIndexForward: true,
+        }));
+        for (const item of (result.Items ?? [])) {
+          if (item.timestamp?.startsWith(date)) allItems.push({ ...item, _device_id: did });
+        }
+      }
+      allItems.sort((a, b) => (a.timestamp ?? "").localeCompare(b.timestamp ?? ""));
+      const dayItems = allItems;
 
       // 単価キャッシュとレート取得
       await loadPricingCache();
@@ -484,6 +506,7 @@ export const handler = async (event) => {
           conversations.push({
             timestamp: item.timestamp,
             session_id: item.session_id,
+            device_id: item._device_id ?? item.device_id ?? deviceId,
             user_message: lastUserContent,
             assistant_message: item.content,
             character_id: item.character_id ?? "default",
@@ -493,7 +516,7 @@ export const handler = async (event) => {
         }
       }
 
-      return response(200, { date, device_id: deviceId, conversations });
+      return response(200, { date, conversations });
     }
 
     return response(404, { error: "Not found" });

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -15,6 +15,88 @@ const CHAT_LOGS_TABLE      = "toytalker-chat-logs";
 const LLMS_TABLE           = "toytalker-llms";
 const USAGE_TABLE          = "toytalker-usage";
 const EXCHANGE_RATES_TABLE = "toytalker-exchange-rates";
+const UNIT_PRICES_TABLE    = "toytalker-api-unit-prices";
+
+// ---- 単価キャッシュ（コスト計算用） ----
+let cachedPrices = null;
+let cachedMargin = 1.5;
+let cacheLoadedAt = 0;
+
+async function loadPricingCache() {
+  if (cachedPrices && (Date.now() - cacheLoadedAt) < 3600_000) return;
+  try {
+    const result = await ddb.send(new ScanCommand({
+      TableName: UNIT_PRICES_TABLE,
+      FilterExpression: "version = :v",
+      ExpressionAttributeValues: { ":v": "current" },
+    }));
+    const prices = {};
+    for (const item of (result.Items ?? [])) {
+      const pk = item["provider#api_type"];
+      if (pk === "service#margin") {
+        cachedMargin = Number(item.margin) || 1.5;
+      } else {
+        prices[pk] = item;
+      }
+    }
+    cachedPrices = prices;
+    cacheLoadedAt = Date.now();
+  } catch (e) {
+    console.error("[Pricing] cache load error:", e);
+  }
+}
+
+function calcCostFromLog(assistantItem, userContent, usdJpyRate) {
+  const margin = cachedMargin;
+  const result = { stt: null, llm: null, tts: null, total: 0 };
+
+  // LLM
+  const llmKey = `${assistantItem.llm_provider}#llm`;
+  const llmPrice = cachedPrices?.[llmKey];
+  if (llmPrice && (assistantItem.llm_tokens_in || assistantItem.llm_tokens_out)) {
+    const tokIn = Number(assistantItem.llm_tokens_in) || 0;
+    const tokOut = Number(assistantItem.llm_tokens_out) || 0;
+    let costUsd = tokIn * Number(llmPrice.unit_price_input) + tokOut * Number(llmPrice.unit_price_output);
+    const costJpy = costUsd * usdJpyRate * margin;
+    result.llm = { cost: Math.round(costJpy * 1000) / 1000, tokens_in: tokIn, tokens_out: tokOut, provider: assistantItem.llm_provider, model: assistantItem.llm_model };
+    result.total += costJpy;
+  }
+
+  // TTS
+  const ttsVendor = assistantItem.tts_provider;
+  const ttsKey = `${ttsVendor}#tts`;
+  const ttsPrice = cachedPrices?.[ttsKey];
+  if (ttsPrice) {
+    const chars = Number(assistantItem.tts_input_units) || 0;
+    let costJpy = 0;
+    if (ttsPrice.currency === "JPY") {
+      costJpy = chars * Number(ttsPrice.unit_price_input) * margin;
+    } else if (ttsPrice.input_unit_type === "utf8_bytes") {
+      const utf8Bytes = chars * 3;
+      costJpy = utf8Bytes * Number(ttsPrice.unit_price_input) * usdJpyRate * margin;
+    } else {
+      costJpy = chars * Number(ttsPrice.unit_price_input) * usdJpyRate * margin;
+    }
+    result.tts = { cost: Math.round(costJpy * 1000) / 1000, characters: chars, provider: ttsVendor, model: assistantItem.tts_provider };
+    result.total += costJpy;
+  }
+
+  // STT (確定文の文字数から概算)
+  const userChars = userContent?.length ?? 0;
+  const sttPrice = cachedPrices?.["soniox#stt"];
+  if (sttPrice && userChars > 0) {
+    const textTokens = Math.round(userChars * 0.3);
+    const speechSec = userChars / 6;
+    const audioTokens = Math.round(speechSec * (30000 / 3600));
+    const costUsd = audioTokens * Number(sttPrice.unit_price_input) + textTokens * Number(sttPrice.unit_price_output);
+    const costJpy = costUsd * usdJpyRate * margin;
+    result.stt = { cost: Math.round(costJpy * 1000) / 1000, characters: userChars };
+    result.total += costJpy;
+  }
+
+  result.total = Math.round(result.total * 1000) / 1000;
+  return result;
+}
 
 const response = (statusCode, body) => ({
   statusCode,
@@ -348,6 +430,62 @@ export const handler = async (event) => {
         by_device: byDevice,
         exchange_rate: exchangeRate,
       });
+    }
+
+    // ---- GET /usage/detail ---- 日次詳細（会話ごとのコスト）
+    if (method === "GET" && path === "/usage/detail") {
+      const ownerId  = event.queryStringParameters?.owner_id  ?? "user_123";
+      const deviceId = event.queryStringParameters?.device_id ?? "app";
+      const date     = event.queryStringParameters?.date;
+      if (!date) return response(400, { error: "date is required" });
+
+      const pk = `owner_id#${ownerId}#device_id#${deviceId}`;
+      const result = await ddb.send(new QueryCommand({
+        TableName: CHAT_LOGS_TABLE,
+        KeyConditionExpression: "#pk = :pk",
+        ExpressionAttributeNames: { "#pk": "owner_id#device_id" },
+        ExpressionAttributeValues: { ":pk": pk },
+        ScanIndexForward: true,
+      }));
+
+      // 該当日のログだけフィルタ
+      const dayItems = (result.Items ?? []).filter(item => item.timestamp?.startsWith(date));
+
+      // 単価キャッシュとレート取得
+      await loadPricingCache();
+      const month = date.slice(0, 7);
+      let usdJpyRate = 150;
+      try {
+        const rateResult = await ddb.send(new GetCommand({
+          TableName: EXCHANGE_RATES_TABLE,
+          Key: { month, currency: "JPY" },
+        }));
+        usdJpyRate = Number(rateResult.Item?.rate) || 150;
+      } catch (e) {}
+
+      // user→assistantペアで組み立て
+      const conversations = [];
+      let lastUserContent = null;
+      for (const item of dayItems) {
+        if (item.role === "user") {
+          lastUserContent = item.content;
+        } else if (item.role === "assistant") {
+          const costs = calcCostFromLog(item, lastUserContent, usdJpyRate);
+          conversations.push({
+            timestamp: item.timestamp,
+            session_id: item.session_id,
+            user_message: lastUserContent,
+            assistant_message: item.content,
+            stt: costs.stt,
+            llm: costs.llm,
+            tts: costs.tts,
+            total: costs.total,
+          });
+          lastUserContent = null;
+        }
+      }
+
+      return response(200, { date, device_id: deviceId, conversations });
     }
 
     return response(404, { error: "Not found" });

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -476,6 +476,7 @@ export const handler = async (event) => {
             session_id: item.session_id,
             user_message: lastUserContent,
             assistant_message: item.content,
+            character_id: item.character_id ?? "default",
             stt: costs.stt,
             llm: costs.llm,
             tts: costs.tts,

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -463,24 +463,31 @@ export const handler = async (event) => {
         usdJpyRate = Number(rateResult.Item?.rate) || 150;
       } catch (e) {}
 
-      // user→assistantペアで組み立て
+      // user→assistantペアで組み立て（chat-logに保存済みのコストを使用）
       const conversations = [];
       let lastUserContent = null;
       for (const item of dayItems) {
         if (item.role === "user") {
           lastUserContent = item.content;
         } else if (item.role === "assistant") {
-          const costs = calcCostFromLog(item, lastUserContent, usdJpyRate);
+          const hasCost = item.cost_total != null;
+          let stt, llm, tts, total;
+          if (hasCost) {
+            stt = { cost: item.cost_stt ?? 0, characters: lastUserContent?.length ?? 0 };
+            llm = { cost: item.cost_llm ?? 0, tokens_in: item.llm_tokens_in, tokens_out: item.llm_tokens_out, provider: item.llm_provider, model: item.llm_model };
+            tts = { cost: item.cost_tts ?? 0, characters: item.tts_input_units, provider: item.tts_provider, model: item.tts_provider };
+            total = item.cost_total;
+          } else {
+            const costs = calcCostFromLog(item, lastUserContent, usdJpyRate);
+            stt = costs.stt; llm = costs.llm; tts = costs.tts; total = costs.total;
+          }
           conversations.push({
             timestamp: item.timestamp,
             session_id: item.session_id,
             user_message: lastUserContent,
             assistant_message: item.content,
             character_id: item.character_id ?? "default",
-            stt: costs.stt,
-            llm: costs.llm,
-            tts: costs.tts,
-            total: costs.total,
+            stt, llm, tts, total,
           });
           lastUserContent = null;
         }


### PR DESCRIPTION
## Summary
- DynamoDBテーブル3つ（toytalker-usage, toytalker-exchange-rates, toytalker-api-unit-prices）でコスト管理
- stream-handler Lambda（app/ESP32両方）にコスト計算+usage書き込み+chat-logへのコスト保存を追加
- device-setting Lambdaに GET /usage（月次集計）、GET /usage/detail（日次詳細・全デバイス対応）を追加
- フロントエンド利用状況ページ: 月別合計、デバイス別、日別バーチャート、API種別カード、詳細ページ（会話ごとのコスト・キャラ名・デバイス名・ローカル時刻）
- コスト計算をstream-handlerに一本化し、addUsage/saveLogをawaitして書き漏れを防止

## Test plan
- [x] アプリから会話してusageテーブルに記録されることを確認
- [x] ESP32から会話してusageテーブルに記録されることを確認
- [x] 利用状況ページで月別合計・デバイス別・日別・API種別が表示されることを確認
- [x] 詳細ページで会話ごとのコスト・キャラ名・デバイス名が表示されることを確認
- [x] 利用状況ページと詳細ページの金額が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)