### PR TITLE
Fix STT truncation and conversation history

### DIFF
--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -569,22 +569,21 @@ export default function Chat() {
         for (const t of tokens) {
           const txt = t.text ?? "";
           if (!txt) continue;
-          // ★ is_final関係なく、常にpartialとして扱う
-          // "<end>" はSTT終了シグナルなので破棄
           if (txt.trim() === "<end>") {
-            // ★ Sonioxのエンド通知。即座に自分でクローズ
             if (DEBUG) setLog(L => [...L, "Soniox: <end> detected, closing WS"]);
             try { ws.close(); } catch {}
             continue;
           }
-          nonFinalCurrent += txt;
+          if (t.is_final) {
+            sonioxFinalBufRef.current += txt;
+          } else {
+            nonFinalCurrent += txt;
+          }
         }
-        if (nonFinalCurrent.trim()) {
-          sonioxNonFinalBufRef.current = nonFinalCurrent;
-          setPartial(nonFinalCurrent);
-        } else {
-          // 空chunkなら破棄せず、最後のpartialを保持したままにする
-          if (DEBUG) setLog(L => [...L, "Soniox: skip empty nonFinal"]);
+        sonioxNonFinalBufRef.current = nonFinalCurrent;
+        const fullText = sonioxFinalBufRef.current + nonFinalCurrent;
+        if (fullText.trim()) {
+          setPartial(fullText);
         }
       } catch (e: any) {
         setLog(L => [...L, `Soniox parse err: ${e?.message ?? e}`]);
@@ -615,13 +614,12 @@ export default function Chat() {
       sonioxListeningRef.current = false;
       setIsListening(false);
 
-      const partialOnly = sonioxNonFinalBufRef.current.trim();
-      if (partialOnly) {
-        //会話履歴に表示
-        setLog(L => [...L, JSON.stringify({ type: "user", text: partialOnly })]);
+      const fullText = (sonioxFinalBufRef.current + sonioxNonFinalBufRef.current).trim();
+      if (fullText) {
+        setLog(L => [...L, JSON.stringify({ type: "user", text: fullText })]);
         setPartial("");
-        if (DEBUG) setLog(L => [...L, `🚀 Send partial-only (fast): ${partialOnly}`]);
-        send(partialOnly);
+        if (DEBUG) setLog(L => [...L, `🚀 Send (final+partial): ${fullText}`]);
+        send(fullText);
       }
     };
   };
@@ -924,6 +922,7 @@ export default function Chat() {
               }
             }
             if (final) {
+              historyRef.current.push({ role: "user", text: t, ts: Date.now() });
               const whole = curAssistantRef.current.trim();
               if (whole) {
                 historyRef.current.push({ role: "assistant", text: whole, ts: Date.now() });
@@ -999,11 +998,14 @@ export default function Chat() {
       }
 
       const recentTurns = historyRef.current.slice(-HISTORY_TURNS_TO_SEND);
-      const historyMessages = recentTurns.map((t) => ({ role: t.role, content: t.text }));
+      const historyMessages = [
+        ...recentTurns.map((t) => ({ role: t.role, content: t.text })),
+        { role: "user", content: t },
+      ];
 
       const payload = {
         character_id: selectedCharacterRef.current.character_id,
-        messages: [...historyMessages, { role: "user", content: t }],
+        messages: historyMessages,
         session_id: sessionIdRef.current,
         owner_id: ownerId,
         device_id: "app",

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.1/toytalker_mini_v0.1.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.1/toytalker_mini_v0.1.ino
@@ -113,6 +113,7 @@ volatile bool wifiGotIP = false;
 // ==== Soniox STT 状態 ====
 WebSocketsClient ws;
 String partialText = "";
+String sonioxFinalBuf = "";
 String lastFinalText = "";
 unsigned long lastPartialMs = 0;
 const unsigned long END_SILENCE_MS = 800;
@@ -980,27 +981,35 @@ void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
     case WStype_TEXT: {
       String msg = (char*)payload;
       if (msg.indexOf("\"tokens\"") >= 0) {
-        String newText = "";
+        String nonFinalCurrent = "";
         bool foundEndToken = false;
-        int pos = 0;
-        while ((pos = msg.indexOf("\"text\":\"", pos)) >= 0) {
-          pos += 8;
-          int end = msg.indexOf("\"", pos);
-          if (end < 0) break;
-          String token = msg.substring(pos, end);
+        int searchPos = msg.indexOf("\"tokens\"");
+        while (true) {
+          int textPos = msg.indexOf("\"text\":\"", searchPos);
+          if (textPos < 0) break;
+          textPos += 8;
+          int textEnd = msg.indexOf("\"", textPos);
+          if (textEnd < 0) break;
+          String token = msg.substring(textPos, textEnd);
+
+          int objEnd = msg.indexOf("}", textEnd);
+          if (objEnd < 0) objEnd = msg.length();
+          String objSlice = msg.substring(textEnd, objEnd);
+          bool isFinal = objSlice.indexOf("\"is_final\":true") >= 0;
+
           if (token == "\\u003cend\\u003e") {
-            foundEndToken = true;  // <end>トークン検出
+            foundEndToken = true;
+          } else if (isFinal) {
+            sonioxFinalBuf += token;
           } else {
-            newText += token;
+            nonFinalCurrent += token;
           }
+          searchPos = textEnd + 1;
         }
 
-        if (newText.length() > 0) {
-          if (newText.startsWith(partialText)) {
-            partialText = newText;
-          } else {
-            partialText = newText;
-          }
+        String fullText = sonioxFinalBuf + nonFinalCurrent;
+        if (fullText.length() > 0) {
+          partialText = fullText;
           lastPartialMs = millis();
           armed = true;
           Serial.println("📝 " + partialText);
@@ -1044,6 +1053,7 @@ void startSTTRecording() {
   ws.enableHeartbeat(15000, 3000, 2);
 
   partialText = "";
+  sonioxFinalBuf = "";
   lastFinalText = "";
   armed = false;
   endpointDetected = false;
@@ -1334,6 +1344,7 @@ void loop() {
     endpointDetected = false;
     armed = false;
     partialText = "";
+    sonioxFinalBuf = "";
   }
   // 無音検出 → 確定文出力（フォールバック）
   else if (armed && partialText.length() > 0 && (millis() - lastPartialMs) >= END_SILENCE_MS) {
@@ -1345,5 +1356,6 @@ void loop() {
     }
     armed = false;
     partialText = "";
+    sonioxFinalBuf = "";
   }
 }


### PR DESCRIPTION
## Summary
- Soniox STTのis_finalトークンを蓄積し、長文発話でテキストが途切れる問題を修正（アプリ・ESP32両方）
- アプリの会話履歴にuserの発話が含まれていなかったバグを修正（LLMが過去のユーザー発話を認識できるように）
- 履歴pushタイミングをESP32パターンに統一（送信後に保存、失敗時のゴミ防止）

## Test plan
- [x] アプリで長文を話し続けてもテキストが途切れないことを確認
- [x] セッション内で会話を重ねるとLLM input tokensが増加することを確認
- [ ] ESP32で長文発話テストを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)