### PR TITLE
Add backchannel feature and ESP performance optimizations

### DIFF
--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -1078,6 +1078,7 @@ export default function Chat() {
         owner_id: ownerId,
         device_id: "app",
         request_at: new Date().toISOString(),
+        backchannel_fired: backchannelFiredRef.current,
       };
       console.log("🚀 payload to Lambda:", JSON.stringify(payload, null, 2));
       xhr.send(JSON.stringify(payload));

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -203,6 +203,7 @@ export default function Chat() {
     closeDrawer();
     setLog([]);
     historyRef.current = [];
+    pastBackchannelsRef.current = [];
     const newId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     setSessionId(newId);
     sessionIdRef.current = newId;
@@ -444,6 +445,7 @@ export default function Chat() {
   const sonioxNonFinalBufRef = useRef<string>(""); // 非確定の表示用
 
   // 相槌
+  const pastBackchannelsRef = useRef<string[]>([]);
   const backchannelFiredRef = useRef(false);
   const backchannelAudioRef = useRef<{ text: string; audio: string; format: string } | null>(null);
   const sttFinishedRef = useRef(false);
@@ -612,6 +614,7 @@ export default function Chat() {
                     partial_text: bcPartial,
                     character_id: charId,
                     history: historyRef.current.slice(-6).map(t => ({ role: t.role, content: t.text })),
+                    past_backchannels: pastBackchannelsRef.current.slice(-10),
                   }),
                 });
                 console.log("[BC] status=", r.status);
@@ -620,6 +623,7 @@ export default function Chat() {
                 let data = JSON.parse(raw);
                 if (typeof data.body === "string") data = JSON.parse(data.body);
                 console.log("[BC] text=", data.text, "hasAudio=", !!data.audio, "sttDone=", sttFinishedRef.current);
+                if (data.text) pastBackchannelsRef.current.push(data.text);
                 if (data.audio) {
                   if (sttFinishedRef.current) {
                     console.log("[BC] playing now");

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -34,7 +34,7 @@ import Sound from "react-native-sound";
 
 /* === Soniox定数 === */
 const SONIOX_WS_URL = "wss://stt-rt.soniox.com/transcribe-websocket"; // 公式
-const SONIOX_MODEL = "stt-rt-v3";
+let SONIOX_MODEL = "stt-rt-v4";
 const SONIOX_SAMPLE_RATE = 16000;
 const SONIOX_CHANNELS = 1;
 
@@ -473,6 +473,7 @@ export default function Chat() {
     });
     const js = await res.json();
     if (!res.ok || !js?.api_key) throw new Error("Failed to get Soniox temp key");
+    if (js.stt_model) SONIOX_MODEL = js.stt_model;
     return js.api_key as string;
   };
 

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -660,10 +660,6 @@ export default function Chat() {
     ws.onclose = async (e) => {
       if(DEBUG)setLog(L => [...L, `Soniox WS closed: code=${e.code}`]);
 
-      // 録音停止
-      try { await AudioRecord.stop(); } catch {}
-      try { AudioRecord.removeAllListeners?.(); } catch {}
-
       // 状態リセット
       sonioxListeningRef.current = false;
       setIsListening(false);
@@ -674,7 +670,10 @@ export default function Chat() {
         setLog(L => [...L, JSON.stringify({ type: "user", text: fullText })]);
         setPartial("");
 
-        // 相槌音声があれば即再生（ケース2: fetch完了済み）
+        // 本Lambdaへの送信を最優先（録音停止を待たない）
+        send(fullText);
+
+        // 相槌音声があれば再生（ケース2: fetch完了済み）
         const bc = backchannelAudioRef.current;
         if (bc) {
           console.log("[BC] Playing cached backchannel:", bc.text);
@@ -683,10 +682,11 @@ export default function Chat() {
           backchannelAudioRef.current = null;
         }
         // ケース1（fetchがまだ返ってない）はfetch完了時にsttFinishedRefを見て即再生
-
-        if (DEBUG) setLog(L => [...L, `🚀 Send (final+partial): ${fullText}`]);
-        send(fullText);
       }
+
+      // 録音停止（send後に非同期で実行）
+      try { await AudioRecord.stop(); } catch {}
+      try { AudioRecord.removeAllListeners?.(); } catch {}
     };
   };
 

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -55,6 +55,11 @@ const DEBUG_HISTORY = false;
 const STREAM_URL =
   "https://ruc3x2rt3bcnsqxvuyvwdshhh40mzadk.lambda-url.ap-northeast-1.on.aws/";
 
+/* 相槌Lambda */
+const BACKCHANNEL_URL =
+  "https://5zcqptvuekdtfjnl4fian2crnm0alohv.lambda-url.ap-northeast-1.on.aws/";
+const BACKCHANNEL_TRIGGER_CHARS = 5;
+
 /* === ユーティリティ === */
 function base64ToArrayBuffer(b64: string): ArrayBuffer {
   const binaryString = (global as any).atob
@@ -438,6 +443,11 @@ export default function Chat() {
   const sonioxFinalBufRef = useRef<string>(""); // final確定の蓄積
   const sonioxNonFinalBufRef = useRef<string>(""); // 非確定の表示用
 
+  // 相槌
+  const backchannelFiredRef = useRef(false);
+  const backchannelAudioRef = useRef<{ text: string; audio: string; format: string } | null>(null);
+  const sttFinishedRef = useRef(false);
+
   const configureAudioRecord = () => {
     AudioRecord.init({
       sampleRate: SONIOX_SAMPLE_RATE,
@@ -537,6 +547,8 @@ export default function Chat() {
         setIsListening(true);
         setPartial(""); setFinalText("");
         sonioxFinalBufRef.current = ""; sonioxNonFinalBufRef.current = "";
+        backchannelFiredRef.current = false; backchannelAudioRef.current = null;
+        sttFinishedRef.current = false;
         if(DEBUG)setLog(L => [...L, "AudioRecord started"]);
       } catch (e: any) {
         setIsListening(false);
@@ -584,6 +596,45 @@ export default function Chat() {
         const fullText = sonioxFinalBufRef.current + nonFinalCurrent;
         if (fullText.trim()) {
           setPartial(fullText);
+
+          // 相槌トリガー: 5文字以上 & まだ発火していない
+          if (!backchannelFiredRef.current && fullText.trim().length >= BACKCHANNEL_TRIGGER_CHARS) {
+            backchannelFiredRef.current = true;
+            const charId = selectedCharacterRef.current.character_id;
+            const bcPartial = fullText.trim();
+            console.log("[BC] fetch firing:", bcPartial, "historyLen=", historyRef.current.length);
+            (async () => {
+              try {
+                const r = await fetch(BACKCHANNEL_URL, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    partial_text: bcPartial,
+                    character_id: charId,
+                    history: historyRef.current.slice(-6).map(t => ({ role: t.role, content: t.text })),
+                  }),
+                });
+                console.log("[BC] status=", r.status);
+                const raw = await r.text();
+                console.log("[BC] raw len=", raw.length);
+                let data = JSON.parse(raw);
+                if (typeof data.body === "string") data = JSON.parse(data.body);
+                console.log("[BC] text=", data.text, "hasAudio=", !!data.audio, "sttDone=", sttFinishedRef.current);
+                if (data.audio) {
+                  if (sttFinishedRef.current) {
+                    console.log("[BC] playing now");
+                    setLog(L => [...L, data.text]);
+                    enqueueAudio(data.audio, `bc-${Date.now()}`, data.format || "wav");
+                  } else {
+                    console.log("[BC] cached for later");
+                    backchannelAudioRef.current = { text: data.text, audio: data.audio, format: data.format || "wav" };
+                  }
+                }
+              } catch (e: any) {
+                console.log("[BC] ERROR:", e?.message ?? e);
+              }
+            })();
+          }
         }
       } catch (e: any) {
         setLog(L => [...L, `Soniox parse err: ${e?.message ?? e}`]);
@@ -613,11 +664,23 @@ export default function Chat() {
       // 状態リセット
       sonioxListeningRef.current = false;
       setIsListening(false);
+      sttFinishedRef.current = true;
 
       const fullText = (sonioxFinalBufRef.current + sonioxNonFinalBufRef.current).trim();
       if (fullText) {
         setLog(L => [...L, JSON.stringify({ type: "user", text: fullText })]);
         setPartial("");
+
+        // 相槌音声があれば即再生（ケース2: fetch完了済み）
+        const bc = backchannelAudioRef.current;
+        if (bc) {
+          console.log("[BC] Playing cached backchannel:", bc.text);
+          setLog(L => [...L, bc.text]);
+          enqueueAudio(bc.audio, `bc-${Date.now()}`, bc.format);
+          backchannelAudioRef.current = null;
+        }
+        // ケース1（fetchがまだ返ってない）はfetch完了時にsttFinishedRefを見て即再生
+
         if (DEBUG) setLog(L => [...L, `🚀 Send (final+partial): ${fullText}`]);
         send(fullText);
       }
@@ -930,7 +993,7 @@ export default function Chat() {
                   setLog((L) => [...L, `🧾 hist +assistant "${whole.slice(0, 40)}"`]);
               }
               curAssistantRef.current = "";
-              console.log("🧾 assistant final segment:", JSON.stringify(whole));
+              console.log("🧾 assistant final segment:", JSON.stringify(whole), "historyLen=", historyRef.current.length);
             }
           } else if (ev === "error") {
             setLog((L) => [...L, `Error: ${dataStr}`]);

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -684,9 +684,10 @@ export default function Chat() {
         // ケース1（fetchがまだ返ってない）はfetch完了時にsttFinishedRefを見て即再生
       }
 
-      // 録音停止（send後に非同期で実行）
+      // 録音停止 + 再生モードに切り替え（send後に非同期で実行）
       try { await AudioRecord.stop(); } catch {}
       try { AudioRecord.removeAllListeners?.(); } catch {}
+      await restoreIOSPlayback();
     };
   };
 

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -105,11 +105,17 @@ export default function Chat() {
 
   // STTモード
   const [sttMode, setSttMode] = useState<"local" | "soniox">("soniox");
+  const [backchannelEnabled, setBackchannelEnabled] = useState(true);
+  const backchannelEnabledRef = useRef(true);
   useFocusEffect(
     useCallback(() => {
       (async () => {
         const saved = await AsyncStorage.getItem("sttMode");
         if (saved === "local" || saved === "soniox") setSttMode(saved);
+        const bcSaved = await AsyncStorage.getItem("backchannelEnabled");
+        const enabled = bcSaved !== "false";
+        setBackchannelEnabled(enabled);
+        backchannelEnabledRef.current = enabled;
       })();
     }, [])
   );
@@ -599,8 +605,8 @@ export default function Chat() {
         if (fullText.trim()) {
           setPartial(fullText);
 
-          // 相槌トリガー: 5文字以上 & まだ発火していない
-          if (!backchannelFiredRef.current && fullText.trim().length >= BACKCHANNEL_TRIGGER_CHARS) {
+          // 相槌トリガー: 有効 & 5文字以上 & まだ発火していない
+          if (backchannelEnabledRef.current && !backchannelFiredRef.current && fullText.trim().length >= BACKCHANNEL_TRIGGER_CHARS) {
             backchannelFiredRef.current = true;
             const charId = selectedCharacterRef.current.character_id;
             const bcPartial = fullText.trim();

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -650,13 +650,6 @@ export default function Chat() {
     ws.onclose = async (e) => {
       if(DEBUG)setLog(L => [...L, `Soniox WS closed: code=${e.code}`]);
 
-      // ★チャット履歴保持のための一時設定
-      const leftover = curAssistantRef.current.trim();
-      if (leftover) {
-        historyRef.current.push({ role: "assistant", text: leftover, ts: Date.now() });
-        curAssistantRef.current = "";
-      }
-
       // 録音停止
       try { await AudioRecord.stop(); } catch {}
       try { AudioRecord.removeAllListeners?.(); } catch {}
@@ -985,15 +978,7 @@ export default function Chat() {
               }
             }
             if (final) {
-              historyRef.current.push({ role: "user", text: t, ts: Date.now() });
-              const whole = curAssistantRef.current.trim();
-              if (whole) {
-                historyRef.current.push({ role: "assistant", text: whole, ts: Date.now() });
-                if (DEBUG_HISTORY)
-                  setLog((L) => [...L, `🧾 hist +assistant "${whole.slice(0, 40)}"`]);
-              }
-              curAssistantRef.current = "";
-              console.log("🧾 assistant final segment:", JSON.stringify(whole), "historyLen=", historyRef.current.length);
+              console.log("🧾 final segment received");
             }
           } else if (ev === "error") {
             setLog((L) => [...L, `Error: ${dataStr}`]);
@@ -1052,6 +1037,15 @@ export default function Chat() {
         if (tail) processChunk(tail);
         const out = accText.trim();
         if (DEBUG) setLog((L) => [...L, "=== stream done ==="]);
+
+        historyRef.current.push({ role: "user", text: t, ts: Date.now() });
+        const whole = curAssistantRef.current.trim();
+        if (whole) {
+          historyRef.current.push({ role: "assistant", text: whole, ts: Date.now() });
+        }
+        curAssistantRef.current = "";
+        console.log("🧾 xhr.onload history push: historyLen=", historyRef.current.length);
+
         sendingRef.current = false;
       };
 

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -12,6 +12,7 @@ import {
   ScrollView,
   Animated,
   Dimensions,
+  Switch,
 } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useRef, useState } from "react";
@@ -75,6 +76,9 @@ export default function Settings() {
   // STT設定
   const [sttMode, setSttMode] = useState<"local" | "soniox">("soniox");
 
+  // 相槌設定
+  const [backchannelEnabled, setBackchannelEnabled] = useState(true);
+
   // キャラクター管理
   const [characters, setCharacters] = useState<CharacterItem[]>([]);
   const [charsLoading, setCharsLoading] = useState(false);
@@ -112,6 +116,8 @@ export default function Settings() {
     (async () => {
       const saved = await AsyncStorage.getItem("sttMode");
       if (saved === "local" || saved === "soniox") setSttMode(saved);
+      const bcSaved = await AsyncStorage.getItem("backchannelEnabled");
+      if (bcSaved === "false") setBackchannelEnabled(false);
     })();
   }, []);
 
@@ -941,6 +947,17 @@ export default function Settings() {
             <Text style={s.navText}>音声認識</Text>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
+
+          <View style={s.navRow}>
+            <Text style={s.navText}>相槌（あいづち）</Text>
+            <Switch
+              value={backchannelEnabled}
+              onValueChange={async (val) => {
+                setBackchannelEnabled(val);
+                await AsyncStorage.setItem("backchannelEnabled", val ? "true" : "false");
+              }}
+            />
+          </View>
 
           <TouchableOpacity style={s.navRow} onPress={openCharacterList}>
             <Text style={s.navText}>キャラクター管理</Text>

--- a/app/app/(tabs)/toy.tsx
+++ b/app/app/(tabs)/toy.tsx
@@ -14,6 +14,7 @@ import {
   Platform,
   PermissionsAndroid,
   ScrollView,
+  Switch,
 } from "react-native";
 import { BleManager, Device } from "react-native-ble-plx";
 
@@ -47,6 +48,7 @@ type RegisteredDevice = {
   character_id: string | null;
   owner_id: string;
   device_name: string;
+  backchannel_enabled?: boolean;
 };
 
 type SessionItem = {
@@ -119,6 +121,7 @@ export default function Toy() {
             character_id: d.character_id,
             owner_id: d.owner_id,
             device_name: d.device_name ?? "",
+            backchannel_enabled: d.backchannel_enabled !== false,
           }));
           setRegisteredDevices(devices);
           await AsyncStorage.setItem("registeredDevices", JSON.stringify(devices));
@@ -610,6 +613,27 @@ export default function Toy() {
             </View>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
+          <View style={s.settingRow}>
+            <Text style={s.settingLabel}>相槌（あいづち）</Text>
+            <Switch
+              value={currentDevice?.backchannel_enabled !== false}
+              onValueChange={async (val) => {
+                setRegisteredDevices((prev) => {
+                  const updated = prev.map((d) => (d.device_id === deviceId ? { ...d, backchannel_enabled: val } : d));
+                  AsyncStorage.setItem("registeredDevices", JSON.stringify(updated));
+                  return updated;
+                });
+                try {
+                  await fetch(`${DEVICE_SETTING_URL}/devices/${encodeURIComponent(deviceId!)}`, {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ backchannel_enabled: val }),
+                  });
+                } catch {}
+                Alert.alert("設定を変更しました", "おもちゃの電源を入れ直してください");
+              }}
+            />
+          </View>
           <TouchableOpacity style={s.settingRow} onPress={openConversationLog}>
             <View>
               <Text style={s.settingLabel}>会話ログ</Text>

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -616,7 +616,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       if (systemMsg) {
         body.systemInstruction = { parts: [{ text: systemMsg.content }] };
       }
-      body.generationConfig = { temperature: 0.7 };
+      body.generationConfig = { temperature: 0.7, thinkingConfig: { thinkingBudget: 0 } };
 
       const key = process.env.GOOGLE_API_KEY;
       const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${key}`;
@@ -646,7 +646,9 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
             if (data === "[DONE]") return;
             try {
               const parsed = JSON.parse(data);
-              const text = parsed.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+              const parts = parsed.candidates?.[0]?.content?.parts ?? [];
+              const textPart = parts.find(p => p.text !== undefined && !p.thought);
+              const text = textPart?.text ?? "";
               if (parsed.usageMetadata) {
                 llmTokensIn  = parsed.usageMetadata.promptTokenCount ?? 0;
                 llmTokensOut = parsed.usageMetadata.candidatesTokenCount ?? 0;

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -491,6 +491,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
     const body    = event.body ? JSON.parse(event.body) : {};
     const messages= body.messages ?? [{ role:"user", content:"自己紹介して" }];
     const deviceId = typeof body.device_id === "string" ? body.device_id : null;
+    const backchannelFired = !!body.backchannel_fired;
 
     // ---- ログ用メタデータ ----
     const sessionId  = typeof body.session_id === "string" ? body.session_id : "unknown";
@@ -565,7 +566,8 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
 
     // システムプロンプトを追加（キャラクターの個性 + 共通指示）
     const now = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo", year: "numeric", month: "long", day: "numeric", weekday: "short", hour: "2-digit", minute: "2-digit" });
-    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。相手が話した言語で返答してください。`;
+    const backchannelHint = backchannelFired ? "\n【重要】相槌は別途再生済みです。返答の冒頭に「うんうん」「そうなんだ」「なるほど」「へぇ」「おお」などの相槌・感嘆詞を絶対に入れないでください。最初の一文字目から本題の内容で返答を始めてください。" : "";
+    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。相手が話した言語で返答してください。${backchannelHint}`;
     const systemPrompt = {
       role: "system",
       content: personalityPrompt ? `${personalityPrompt}\n\n${basePrompt}` : basePrompt,

--- a/backend/toytalk-soniox-stt-lambda/deploy.sh
+++ b/backend/toytalk-soniox-stt-lambda/deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+
+echo "📦 Bundling with esbuild..."
+"/c/Program Files/nodejs/npx.cmd" esbuild index.mjs --bundle --platform=node --format=esm \
+  --external:@aws-sdk/client-dynamodb \
+  --external:@aws-sdk/lib-dynamodb \
+  --outfile=bundle.mjs
+
+echo "📁 Creating zip..."
+mkdir -p temp_deploy
+cp bundle.mjs temp_deploy/index.mjs
+cd temp_deploy
+powershell -Command "Compress-Archive -Path 'index.mjs' -DestinationPath '../deploy.zip' -Force"
+cd ..
+rm -rf temp_deploy
+
+echo "🚀 Deploying to Lambda..."
+aws lambda update-function-code \
+  --function-name toytalk-soniox-stt-lambda \
+  --zip-file fileb://deploy.zip \
+  --region ap-northeast-1 \
+  --query '[CodeSize, LastModified]' \
+  --output text
+
+echo "✅ Done!"

--- a/backend/toytalk-soniox-stt-lambda/index.mjs
+++ b/backend/toytalk-soniox-stt-lambda/index.mjs
@@ -57,6 +57,7 @@ export const handler = async (event) => {
     const data = await sonioxRes.json();
 
     const result = { ok: true, ...data };
+    result.stt_model = process.env.SONIOX_MODEL || "stt-rt-v4";
     if (deviceSettings?.Item) {
       result.backchannel_enabled = deviceSettings.Item.backchannel_enabled !== false;
     }

--- a/backend/toytalk-soniox-stt-lambda/index.mjs
+++ b/backend/toytalk-soniox-stt-lambda/index.mjs
@@ -1,3 +1,10 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+
+const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
+const ddb = DynamoDBDocumentClient.from(ddbClient);
+const DEVICES_TABLE = "toytalker-devices";
+
 export const handler = async (event) => {
   try {
     const SONIOX_API_KEY = process.env.SONIOX_API_KEY;
@@ -11,40 +18,53 @@ export const handler = async (event) => {
     // Soniox temporary key API
     const url = "https://api.soniox.com/v1/auth/temporary-api-key";
 
-    // 1時間有効 (3600秒)
     const body = {
       usage_type: "transcribe_websocket",
       expires_in_seconds: 3600,
-      client_reference_id: "toytalk-lambda", // 任意
+      client_reference_id: "toytalk-lambda",
     };
 
-    const res = await fetch(url, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${SONIOX_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
+    // Soniox API呼び出しとデバイス設定取得を並列実行
+    const deviceId = event.queryStringParameters?.device_id ?? null;
 
-    if (!res.ok) {
-      const text = await res.text();
+    const [sonioxRes, deviceSettings] = await Promise.all([
+      fetch(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${SONIOX_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }),
+      deviceId ? ddb.send(new GetCommand({
+        TableName: DEVICES_TABLE,
+        Key: { device_id: deviceId },
+      })).catch(() => null) : Promise.resolve(null),
+    ]);
+
+    if (!sonioxRes.ok) {
+      const text = await sonioxRes.text();
       return {
-        statusCode: res.status,
+        statusCode: sonioxRes.status,
         body: JSON.stringify({
           error: "Soniox API error",
-          status: res.status,
+          status: sonioxRes.status,
           details: text,
         }),
       };
     }
 
-    const data = await res.json();
+    const data = await sonioxRes.json();
+
+    const result = { ok: true, ...data };
+    if (deviceSettings?.Item) {
+      result.backchannel_enabled = deviceSettings.Item.backchannel_enabled !== false;
+    }
 
     return {
       statusCode: 200,
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ok: true, ...data }),
+      body: JSON.stringify(result),
     };
   } catch (err) {
     return {

--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -537,6 +537,7 @@
     // 単価キャッシュを先にロード（await不要、バックグラウンドで）
     loadPricingCache();
 
+    const backchannelFired = !!body.backchannel_fired;
     const characterId = typeof body.character_id === "string" ? body.character_id : null;
     if (characterId && characterId !== "default") {
       const charConfig = await resolveCharacterFromDynamo(characterId);
@@ -592,7 +593,8 @@
       send(res, "mark", { k: "llm_start", t: Date.now() });
     }
     const now = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo", year: "numeric", month: "long", day: "numeric", weekday: "short", hour: "2-digit", minute: "2-digit" });
-    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。相手が話した言語で返答してください。`;
+    const backchannelHint = backchannelFired ? "\n【重要】相槌は別途再生済みです。返答の冒頭に「うんうん」「そうなんだ」「なるほど」「へぇ」「おお」などの相槌・感嘆詞を絶対に入れないでください。最初の一文字目から本題の内容で返答を始めてください。" : "";
+    const basePrompt = `あなたは子供向けの友好的な音声アシスタントです。簡潔に答えて、自然に会話を続けてください。漢字は最小限にして、ひらがな多めで答えてください。単語の間に半角スペースを入れないでください。現在の日時は${now}です。日時を聞かれたら年は省略して簡潔に答えてください。相手が話した言語で返答してください。${backchannelHint}`;
     const systemContent = personalityPrompt ? `${personalityPrompt}\n\n${basePrompt}` : basePrompt;
     const messagesWithSystem = [{ role: "system", content: systemContent }, ...messages];
 

--- a/backend/toytalker-backchannel-for-app-lambda/index.mjs
+++ b/backend/toytalker-backchannel-for-app-lambda/index.mjs
@@ -63,27 +63,33 @@ async function resolveCharacter(characterId) {
 }
 
 // ---- Haiku LLM (相槌生成) ----
-async function generateBackchannel(partialText, personalityPrompt, history = []) {
+async function generateBackchannel(partialText, personalityPrompt, history = [], pastBackchannels = []) {
   const key = process.env.GOOGLE_API_KEY;
   if (!key) throw new Error("GOOGLE_API_KEY is not set");
+
+  const now = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo", hour: "numeric", minute: "numeric" });
+  const isFirstTurn = history.length === 0;
 
   const historyContext = history.length > 0
     ? "\n直前の会話:\n" + history.map(h => `${h.role === "user" ? "ユーザー" : "あなた"}: ${h.content}`).join("\n") + "\n"
     : "";
 
+  const firstTurnHint = isFirstTurn
+    ? `\n- 会話の最初なので、時間帯（現在${now}）に合った挨拶で返してもよい（必須ではない）`
+    : "";
+
+  const avoidHint = pastBackchannels.length > 0
+    ? `\n- 過去に使った相槌: ${pastBackchannels.join("、")}。これらとは違う表現を使うこと`
+    : "";
+
   const systemPrompt = `あなたは会話相手で、相槌を打つ役割です。${personalityPrompt ? "あなたの性格: " + personalityPrompt + "\n" : ""}${historyContext}ユーザーが今まさに話している途中です。聞こえている部分と会話の流れに合った、自然な相槌を一言だけ返してください。
 ルール:
-- 相槌とは「聞いているよ」「わかるよ」という反応のこと
-- 必ず1〜8文字程度の短い相槌のみ
+- 相槌とは「聞いているよ」「わかるよ」という短い反応のこと
+- 1〜10文字程度
 - 句読点不要
-- 会話の流れに合わせてバリエーション豊かに（同じ相槌の連続を避ける）
-- 楽しい話題: わぁ、いいね、おー、やったー
-- 困った話題: えぇー、うーん、そっかぁ
-- 驚き: えっ、まじで、ほんとに
-- 共感: わかる、だよね、そうそう
-- 挨拶: おはよう、こんにちは、やっほー（会話の最初のみ）
-- 普通の相槌: うんうん、へぇー、そうなんだ、なるほど、ふーん
-- キャラの口調を反映してよいが、相槌として不自然な語尾は使わない
+- 話題の内容や感情に合った相槌を自分で考えて返す（楽しい・困っている・驚き・共感など）
+- 会話の流れを見て、毎回違う表現を使う${firstTurnHint}${avoidHint}
+- キャラの口調に少し寄せてもよいが、自然さを最優先する
 - 絶対に質問・返答・感想・コメントはしない。相槌のみ`;
 
   const resp = await fetch(
@@ -258,6 +264,7 @@ export const handler = async (event) => {
     const partialText = body.partial_text ?? "";
     const characterId = body.character_id ?? null;
     const history = Array.isArray(body.history) ? body.history.slice(-6) : [];
+    const pastBackchannels = Array.isArray(body.past_backchannels) ? body.past_backchannels.slice(-10) : [];
 
     if (!partialText) {
       return { statusCode: 400, body: JSON.stringify({ error: "partial_text is required" }) };
@@ -281,7 +288,7 @@ export const handler = async (event) => {
 
     // LLM + TTS を並列実行
     const [backchannelText, _] = await Promise.all([
-      generateBackchannel(partialText, personalityPrompt, history),
+      generateBackchannel(partialText, personalityPrompt, history, pastBackchannels),
       // TTS は backchannelText が必要なので後で実行
     ]);
 

--- a/backend/toytalker-backchannel-for-app-lambda/index.mjs
+++ b/backend/toytalker-backchannel-for-app-lambda/index.mjs
@@ -1,0 +1,313 @@
+// Node.js 18+ / ESM（index.mjs）
+// Handler: index.handler
+// Env: ANTHROPIC_API_KEY, SAKURA_API_KEY, GOOGLE_API_KEY, OPENAI_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+
+const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
+const ddb = DynamoDBDocumentClient.from(ddbClient);
+const CHARACTERS_TABLE = "toytalker-characters";
+const VOICES_TABLE     = "toytalker-voices";
+
+// ---- TTS設定 ----
+const TTS_TABLE = {
+  OpenAI:     { ttsVendor: "openai",     ttsModel: "gpt-4o-mini-tts" },
+  Google:     { ttsVendor: "google",     ttsModel: "google" },
+  Gemini:     { ttsVendor: "gemini",     ttsModel: "gemini-2.5-flash-preview-tts" },
+  ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
+  FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
+  Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
+};
+const TTS_DEFAULT = "Sakura";
+
+function normalizeModelKey(k) {
+  if (!k) return undefined;
+  const s = String(k).toLowerCase();
+  if (s.includes("openai"))      return "OpenAI";
+  if (s.includes("google"))      return "Google";
+  if (s.includes("gemini"))      return "Gemini";
+  if (s.includes("elevenlabs"))  return "ElevenLabs";
+  if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
+  if (s.includes("sakura"))      return "Sakura";
+  return undefined;
+}
+
+// ---- キャラクター解決 ----
+async function resolveCharacter(characterId) {
+  try {
+    const charRes = await ddb.send(new GetCommand({
+      TableName: CHARACTERS_TABLE,
+      Key: { character_id: characterId },
+    }));
+    if (!charRes.Item) return null;
+
+    const voiceId = charRes.Item.voice_id;
+    const personalityPrompt = charRes.Item.personality_prompt || null;
+    if (!voiceId) return null;
+
+    const voiceRes = await ddb.send(new GetCommand({
+      TableName: VOICES_TABLE,
+      Key: { voice_id: voiceId },
+    }));
+    if (!voiceRes.Item) return null;
+
+    return {
+      provider: voiceRes.Item.provider,
+      vendorId: voiceRes.Item.vendor_id,
+      personalityPrompt,
+    };
+  } catch (e) {
+    console.error("[resolveCharacter] error:", e);
+    return null;
+  }
+}
+
+// ---- Haiku LLM (相槌生成) ----
+async function generateBackchannel(partialText, personalityPrompt, history = []) {
+  const key = process.env.GOOGLE_API_KEY;
+  if (!key) throw new Error("GOOGLE_API_KEY is not set");
+
+  const historyContext = history.length > 0
+    ? "\n直前の会話:\n" + history.map(h => `${h.role === "user" ? "ユーザー" : "あなた"}: ${h.content}`).join("\n") + "\n"
+    : "";
+
+  const systemPrompt = `あなたは会話相手で、相槌を打つ役割です。${personalityPrompt ? "あなたの性格: " + personalityPrompt + "\n" : ""}${historyContext}ユーザーが今まさに話している途中です。聞こえている部分と会話の流れに合った、自然な相槌を一言だけ返してください。
+ルール:
+- 相槌とは「聞いているよ」「わかるよ」という反応のこと
+- 必ず1〜8文字程度の短い相槌のみ
+- 句読点不要
+- 会話の流れに合わせてバリエーション豊かに（同じ相槌の連続を避ける）
+- 楽しい話題: わぁ、いいね、おー、やったー
+- 困った話題: えぇー、うーん、そっかぁ
+- 驚き: えっ、まじで、ほんとに
+- 共感: わかる、だよね、そうそう
+- 挨拶: おはよう、こんにちは、やっほー（会話の最初のみ）
+- 普通の相槌: うんうん、へぇー、そうなんだ、なるほど、ふーん
+- キャラの口調を反映してよいが、相槌として不自然な語尾は使わない
+- 絶対に質問・返答・感想・コメントはしない。相槌のみ`;
+
+  const resp = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${key}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: systemPrompt }] },
+        contents: [{ role: "user", parts: [{ text: `（話し中）${partialText}` }] }],
+        generationConfig: { maxOutputTokens: 20, temperature: 0.9, thinkingConfig: { thinkingBudget: 0 } },
+      }),
+    }
+  );
+  if (!resp.ok) {
+    const errText = await resp.text();
+    throw new Error(`Gemini failed: ${resp.status} ${errText}`);
+  }
+  const data = await resp.json();
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "うん";
+  return text.trim();
+}
+
+// ---- TTS functions ----
+
+function pcm16ToWavBase64(pcmBase64, sampleRate, channels) {
+  const pcm = Buffer.from(pcmBase64, "base64");
+  const header = Buffer.alloc(44);
+  const dataSize = pcm.length;
+  const fileSize = 36 + dataSize;
+  header.write("RIFF", 0);
+  header.writeUInt32LE(fileSize, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(sampleRate * channels * 2, 28);
+  header.writeUInt16LE(channels * 2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(dataSize, 40);
+  return Buffer.concat([header, pcm]).toString("base64");
+}
+
+async function ttsToBase64Sakura(text, { model = "zundamon", style = "normal" } = {}) {
+  const key = process.env.SAKURA_API_KEY;
+  if (!key) throw new Error("SAKURA_API_KEY is not set");
+  const resp = await fetch("https://api.ai.sakura.ad.jp/v1/audio/speech", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${key}`,
+      "Content-Type": "application/json",
+      "Accept": "audio/wav",
+    },
+    body: JSON.stringify({ model, input: text, voice: style, response_format: "wav" }),
+  });
+  if (!resp.ok) {
+    const errorText = await resp.text();
+    throw new Error(`Sakura TTS failed: ${resp.status} ${errorText}`);
+  }
+  const wavBuffer = Buffer.from(await resp.arrayBuffer());
+  return wavBuffer.toString("base64");
+}
+
+async function ttsToBase64OpenAI(text, { model = "gpt-4o-mini-tts", voice = "alloy" } = {}) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error("OPENAI_API_KEY is not set");
+  const resp = await fetch("https://api.openai.com/v1/audio/speech", {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ model, input: text, voice, response_format: "wav" }),
+  });
+  if (!resp.ok) throw new Error(`OpenAI TTS failed: ${resp.status}`);
+  const wavBuffer = Buffer.from(await resp.arrayBuffer());
+  return wavBuffer.toString("base64");
+}
+
+async function ttsToBase64Google(text, { voiceName = "ja-JP-Neural2-B", speakingRate = 1.0, pitch = 0, sampleRateHertz = 24000 } = {}) {
+  const key = process.env.GOOGLE_API_KEY;
+  if (!key) throw new Error("GOOGLE_API_KEY is not set");
+  const resp = await fetch(
+    `https://texttospeech.googleapis.com/v1/text:synthesize?key=${key}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        input: { text },
+        voice: { languageCode: "ja-JP", name: voiceName },
+        audioConfig: { audioEncoding: "LINEAR16", speakingRate, pitch, sampleRateHertz },
+      }),
+    }
+  );
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json?.error?.message || "Google TTS failed");
+  return pcm16ToWavBase64(json.audioContent, sampleRateHertz, 1);
+}
+
+async function ttsToBase64Gemini(text, { model = "gemini-2.5-flash-preview-tts", voiceName = "Kore" } = {}) {
+  const key = process.env.GOOGLE_API_KEY;
+  if (!key) throw new Error("GOOGLE_API_KEY is not set");
+  const resp = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
+    {
+      method: "POST",
+      headers: { "x-goog-api-key": key, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: `Read the following text aloud: ${text}` }] }],
+        generationConfig: {
+          responseModalities: ["AUDIO"],
+          speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName } } },
+        },
+        model,
+      }),
+    }
+  );
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json?.error?.message || "Gemini TTS failed");
+  const b64Pcm = json?.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data || "";
+  if (!b64Pcm) throw new Error("Gemini TTS: empty audio");
+  return pcm16ToWavBase64(b64Pcm, 24000, 1);
+}
+
+async function ttsToBase64ElevenLabs(text, { model = "eleven_turbo_v2_5", voiceId = "hMK7c1GPJmptCzI4bQIu" } = {}) {
+  const key = process.env.ELEVENLABS_API_KEY;
+  if (!key) throw new Error("ELEVENLABS_API_KEY is not set");
+  const resp = await fetch(
+    `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream?output_format=pcm_24000&optimize_streaming_latency=0`,
+    {
+      method: "POST",
+      headers: { "xi-api-key": key, "Content-Type": "application/json" },
+      body: JSON.stringify({ text, model_id: model, voice_settings: { stability: 0.5, similarity_boost: 0.75 } }),
+    }
+  );
+  if (!resp.ok) throw new Error(`ElevenLabs TTS failed: ${resp.status}`);
+  const pcmBuf = Buffer.from(await resp.arrayBuffer());
+  return pcm16ToWavBase64(pcmBuf.toString("base64"), 24000, 1);
+}
+
+async function ttsToBase64FishAudio(text, { referenceId = "e58b0d7efca34eb38d5c4985e9e1e3e6" } = {}) {
+  const key = process.env.FISHAUDIO_API_KEY;
+  if (!key) throw new Error("FISHAUDIO_API_KEY is not set");
+  const resp = await fetch("https://api.fish.audio/v1/tts", {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ text, reference_id: referenceId, format: "wav" }),
+  });
+  if (!resp.ok) throw new Error(`FishAudio TTS failed: ${resp.status}`);
+  const wavBuffer = Buffer.from(await resp.arrayBuffer());
+  return wavBuffer.toString("base64");
+}
+
+// ---- TTS ルーティング ----
+async function generateTTS(text, vendor, voice) {
+  switch (vendor) {
+    case "sakura":     return ttsToBase64Sakura(text, { model: voice || "zundamon" });
+    case "openai":     return ttsToBase64OpenAI(text, { voice: voice || "alloy" });
+    case "google":     return ttsToBase64Google(text, { voiceName: voice });
+    case "gemini":     return ttsToBase64Gemini(text, { voiceName: voice || "Kore" });
+    case "elevenlabs": return ttsToBase64ElevenLabs(text, { voiceId: voice });
+    case "fishaudio":  return ttsToBase64FishAudio(text, { referenceId: voice });
+    default:           return ttsToBase64Sakura(text, { model: "zundamon" });
+  }
+}
+
+// ---- Handler ----
+export const handler = async (event) => {
+  const start = Date.now();
+  try {
+    const body = event.body ? JSON.parse(event.body) : {};
+    const partialText = body.partial_text ?? "";
+    const characterId = body.character_id ?? null;
+    const history = Array.isArray(body.history) ? body.history.slice(-6) : [];
+
+    if (!partialText) {
+      return { statusCode: 400, body: JSON.stringify({ error: "partial_text is required" }) };
+    }
+
+    // キャラクター設定を解決
+    let ttsVendor = "sakura";
+    let ttsVoice = "zundamon";
+    let personalityPrompt = null;
+
+    if (characterId && characterId !== "default") {
+      const charConfig = await resolveCharacter(characterId);
+      if (charConfig) {
+        const ttsKey = normalizeModelKey(charConfig.provider) ?? TTS_DEFAULT;
+        const cfg = TTS_TABLE[ttsKey] ?? TTS_TABLE[TTS_DEFAULT];
+        ttsVendor = cfg.ttsVendor;
+        ttsVoice = charConfig.vendorId ?? ttsVoice;
+        personalityPrompt = charConfig.personalityPrompt;
+      }
+    }
+
+    // LLM + TTS を並列実行
+    const [backchannelText, _] = await Promise.all([
+      generateBackchannel(partialText, personalityPrompt, history),
+      // TTS は backchannelText が必要なので後で実行
+    ]);
+
+    console.log(`[Backchannel] "${partialText}" → "${backchannelText}" (${Date.now() - start}ms) history=${history.length}turns`);
+
+    const ttsStart = Date.now();
+    const audioBase64 = await generateTTS(backchannelText, ttsVendor, ttsVoice);
+    console.log(`[TTS] ${ttsVendor}/${ttsVoice} (${Date.now() - ttsStart}ms)`);
+
+    console.log(`[Total] ${Date.now() - start}ms`);
+
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: backchannelText,
+        audio: audioBase64,
+        format: "wav",
+        latency_ms: Date.now() - start,
+      }),
+    };
+  } catch (err) {
+    console.error("[Backchannel] error:", err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: err.message }),
+    };
+  }
+};

--- a/backend/toytalker-backchannel-for-esp32-lambda/deploy.sh
+++ b/backend/toytalker-backchannel-for-esp32-lambda/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# デプロイスクリプト - index.mjs を編集後にこれを実行
+
+cd "$(dirname "$0")"
+
+echo "📦 Bundling with esbuild..."
+"/c/Program Files/nodejs/npx.cmd" esbuild index.mjs --bundle --platform=node --format=esm \
+  --external:@aws-sdk/client-dynamodb \
+  --external:@aws-sdk/lib-dynamodb \
+  --outfile=bundle.mjs
+
+echo "📁 Creating zip..."
+mkdir -p temp_deploy
+cp bundle.mjs temp_deploy/index.mjs
+cd temp_deploy
+powershell -Command "Compress-Archive -Path 'index.mjs' -DestinationPath '../deploy.zip' -Force"
+cd ..
+rm -rf temp_deploy
+
+echo "🚀 Deploying to Lambda..."
+aws lambda update-function-code \
+  --function-name toytalker-backchannel-for-esp32-lambda \
+  --zip-file fileb://deploy.zip \
+  --region ap-northeast-1 \
+  --query '[CodeSize, LastModified]' \
+  --output text
+
+echo "✅ Done!"

--- a/backend/toytalker-backchannel-for-esp32-lambda/index.mjs
+++ b/backend/toytalker-backchannel-for-esp32-lambda/index.mjs
@@ -8,6 +8,7 @@ import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 
 const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
 const ddb = DynamoDBDocumentClient.from(ddbClient);
+const DEVICES_TABLE    = "toytalker-devices";
 const CHARACTERS_TABLE = "toytalker-characters";
 const VOICES_TABLE     = "toytalker-voices";
 
@@ -32,6 +33,26 @@ function normalizeModelKey(k) {
   if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
   if (s.includes("sakura"))      return "Sakura";
   return undefined;
+}
+
+// ---- device_idからキャラクター解決（ESP用） ----
+async function resolveCharacterFromDevice(deviceId) {
+  try {
+    const deviceRes = await ddb.send(new GetCommand({
+      TableName: DEVICES_TABLE,
+      Key: { device_id: deviceId },
+    }));
+    const device = deviceRes.Item;
+    if (!device) return null;
+
+    if (device.character_id && device.character_id !== "default") {
+      return resolveCharacter(device.character_id);
+    }
+    return null;
+  } catch (e) {
+    console.error("[resolveCharacterFromDevice] error:", e);
+    return null;
+  }
 }
 
 // ---- キャラクター解決 ----
@@ -242,6 +263,7 @@ export const handler = async (event) => {
   try {
     const body = event.body ? JSON.parse(event.body) : {};
     const partialText = body.partial_text ?? "";
+    const deviceId = body.device_id ?? null;
     const characterId = body.character_id ?? null;
     const history = Array.isArray(body.history) ? body.history.slice(-6) : [];
     const pastBackchannels = Array.isArray(body.past_backchannels) ? body.past_backchannels.slice(-10) : [];
@@ -250,20 +272,24 @@ export const handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: "partial_text is required" }) };
     }
 
-    // キャラクター設定を解決
+    // キャラクター設定を解決（device_id優先、なければcharacter_id）
     let ttsVendor = "sakura";
     let ttsVoice = "zundamon";
     let personalityPrompt = null;
 
-    if (characterId && characterId !== "default") {
-      const charConfig = await resolveCharacter(characterId);
-      if (charConfig) {
-        const ttsKey = normalizeModelKey(charConfig.provider) ?? TTS_DEFAULT;
-        const cfg = TTS_TABLE[ttsKey] ?? TTS_TABLE[TTS_DEFAULT];
-        ttsVendor = cfg.ttsVendor;
-        ttsVoice = charConfig.vendorId ?? ttsVoice;
-        personalityPrompt = charConfig.personalityPrompt;
-      }
+    let charConfig = null;
+    if (deviceId) {
+      charConfig = await resolveCharacterFromDevice(deviceId);
+    }
+    if (!charConfig && characterId && characterId !== "default") {
+      charConfig = await resolveCharacter(characterId);
+    }
+    if (charConfig) {
+      const ttsKey = normalizeModelKey(charConfig.provider) ?? TTS_DEFAULT;
+      const cfg = TTS_TABLE[ttsKey] ?? TTS_TABLE[TTS_DEFAULT];
+      ttsVendor = cfg.ttsVendor;
+      ttsVoice = charConfig.vendorId ?? ttsVoice;
+      personalityPrompt = charConfig.personalityPrompt;
     }
 
     // LLM生成

--- a/backend/toytalker-backchannel-for-esp32-lambda/index.mjs
+++ b/backend/toytalker-backchannel-for-esp32-lambda/index.mjs
@@ -1,0 +1,297 @@
+// Node.js 18+ / ESM（index.mjs）
+// Handler: index.handler
+// ESP32向け相槌Lambda: raw PCMバイナリをレスポンスボディで返す
+// ヘッダ X-Backchannel-Text に相槌テキストを格納
+// Env: GOOGLE_API_KEY, OPENAI_API_KEY, SAKURA_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
+
+const ddbClient = new DynamoDBClient({ region: "ap-northeast-1" });
+const ddb = DynamoDBDocumentClient.from(ddbClient);
+const CHARACTERS_TABLE = "toytalker-characters";
+const VOICES_TABLE     = "toytalker-voices";
+
+// ---- TTS設定 ----
+const TTS_TABLE = {
+  OpenAI:     { ttsVendor: "openai",     ttsModel: "gpt-4o-mini-tts" },
+  Google:     { ttsVendor: "google",     ttsModel: "google" },
+  Gemini:     { ttsVendor: "gemini",     ttsModel: "gemini-2.5-flash-preview-tts" },
+  ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
+  FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
+  Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
+};
+const TTS_DEFAULT = "Sakura";
+
+function normalizeModelKey(k) {
+  if (!k) return undefined;
+  const s = String(k).toLowerCase();
+  if (s.includes("openai"))      return "OpenAI";
+  if (s.includes("google"))      return "Google";
+  if (s.includes("gemini"))      return "Gemini";
+  if (s.includes("elevenlabs"))  return "ElevenLabs";
+  if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
+  if (s.includes("sakura"))      return "Sakura";
+  return undefined;
+}
+
+// ---- キャラクター解決 ----
+async function resolveCharacter(characterId) {
+  try {
+    const charRes = await ddb.send(new GetCommand({
+      TableName: CHARACTERS_TABLE,
+      Key: { character_id: characterId },
+    }));
+    if (!charRes.Item) return null;
+
+    const voiceId = charRes.Item.voice_id;
+    const personalityPrompt = charRes.Item.personality_prompt || null;
+    if (!voiceId) return null;
+
+    const voiceRes = await ddb.send(new GetCommand({
+      TableName: VOICES_TABLE,
+      Key: { voice_id: voiceId },
+    }));
+    if (!voiceRes.Item) return null;
+
+    return {
+      provider: voiceRes.Item.provider,
+      vendorId: voiceRes.Item.vendor_id,
+      personalityPrompt,
+    };
+  } catch (e) {
+    console.error("[resolveCharacter] error:", e);
+    return null;
+  }
+}
+
+// ---- LLM (相槌生成 - Gemini Flash) ----
+async function generateBackchannel(partialText, personalityPrompt, history = [], pastBackchannels = []) {
+  const key = process.env.GOOGLE_API_KEY;
+  if (!key) throw new Error("GOOGLE_API_KEY is not set");
+
+  const now = new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo", hour: "numeric", minute: "numeric" });
+  const isFirstTurn = history.length === 0;
+
+  const historyContext = history.length > 0
+    ? "\n直前の会話:\n" + history.map(h => `${h.role === "user" ? "ユーザー" : "あなた"}: ${h.content}`).join("\n") + "\n"
+    : "";
+
+  const firstTurnHint = isFirstTurn
+    ? `\n- 会話の最初なので、時間帯（現在${now}）に合った挨拶で返してもよい（必須ではない）`
+    : "";
+
+  const avoidHint = pastBackchannels.length > 0
+    ? `\n- 過去に使った相槌: ${pastBackchannels.join("、")}。これらとは違う表現を使うこと`
+    : "";
+
+  const systemPrompt = `あなたは会話相手で、相槌を打つ役割です。${personalityPrompt ? "あなたの性格: " + personalityPrompt + "\n" : ""}${historyContext}ユーザーが今まさに話している途中です。聞こえている部分と会話の流れに合った、自然な相槌を一言だけ返してください。
+ルール:
+- 相槌とは「聞いているよ」「わかるよ」という短い反応のこと
+- 1〜10文字程度
+- 句読点不要
+- 話題の内容や感情に合った相槌を自分で考えて返す（楽しい・困っている・驚き・共感など）
+- 会話の流れを見て、毎回違う表現を使う${firstTurnHint}${avoidHint}
+- キャラの口調に少し寄せてもよいが、自然さを最優先する
+- 絶対に質問・返答・感想・コメントはしない。相槌のみ`;
+
+  const resp = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${key}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: systemPrompt }] },
+        contents: [{ role: "user", parts: [{ text: `（話し中）${partialText}` }] }],
+        generationConfig: { maxOutputTokens: 20, temperature: 0.9, thinkingConfig: { thinkingBudget: 0 } },
+      }),
+    }
+  );
+  if (!resp.ok) {
+    const errText = await resp.text();
+    throw new Error(`Gemini failed: ${resp.status} ${errText}`);
+  }
+  const data = await resp.json();
+  const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? "うん";
+  return text.trim();
+}
+
+// ---- TTS functions (raw PCM Buffer) ----
+
+async function ttsPcmOpenAI(text, { model = "gpt-4o-mini-tts", voice = "alloy" } = {}) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error("OPENAI_API_KEY is not set");
+  const resp = await fetch("https://api.openai.com/v1/audio/speech", {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ model, input: text, voice, response_format: "pcm" }),
+  });
+  if (!resp.ok) throw new Error(`OpenAI TTS failed: ${resp.status}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function ttsPcmGoogle(text, { voiceName = "ja-JP-Neural2-B", sampleRateHertz = 24000 } = {}) {
+  const key = process.env.GOOGLE_API_KEY;
+  if (!key) throw new Error("GOOGLE_API_KEY is not set");
+  const parts = String(voiceName).split("-");
+  const languageCode = parts.length >= 2 ? `${parts[0]}-${parts[1]}` : "ja-JP";
+  const resp = await fetch(
+    `https://texttospeech.googleapis.com/v1/text:synthesize?key=${key}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        input: { text },
+        voice: { languageCode, name: voiceName },
+        audioConfig: { audioEncoding: "LINEAR16", speakingRate: 1.2, pitch: 3.0, sampleRateHertz },
+      }),
+    }
+  );
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json?.error?.message || "Google TTS failed");
+  return Buffer.from(json.audioContent, "base64");
+}
+
+async function ttsPcmGemini(text, { model = "gemini-2.5-flash-preview-tts", voiceName = "Kore" } = {}) {
+  const key = process.env.GOOGLE_API_KEY;
+  if (!key) throw new Error("GOOGLE_API_KEY is not set");
+  const resp = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
+    {
+      method: "POST",
+      headers: { "x-goog-api-key": key, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text }] }],
+        generationConfig: {
+          responseModalities: ["AUDIO"],
+          speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName } } },
+        },
+        model,
+      }),
+    }
+  );
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json?.error?.message || "Gemini TTS failed");
+  const b64Pcm = json?.candidates?.[0]?.content?.parts?.[0]?.inlineData?.data || "";
+  if (!b64Pcm) throw new Error("Gemini TTS: empty audio");
+  return Buffer.from(b64Pcm, "base64");
+}
+
+async function ttsPcmElevenLabs(text, { model = "eleven_turbo_v2_5", voiceId = "hMK7c1GPJmptCzI4bQIu" } = {}) {
+  const key = process.env.ELEVENLABS_API_KEY;
+  if (!key) throw new Error("ELEVENLABS_API_KEY is not set");
+  const resp = await fetch(
+    `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}/stream?output_format=pcm_24000&optimize_streaming_latency=0`,
+    {
+      method: "POST",
+      headers: { "xi-api-key": key, "Content-Type": "application/json" },
+      body: JSON.stringify({ text, model_id: model, voice_settings: { stability: 0.5, similarity_boost: 0.75 } }),
+    }
+  );
+  if (!resp.ok) throw new Error(`ElevenLabs TTS failed: ${resp.status}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function ttsPcmFishAudio(text, { referenceId = "e58b0d7efca34eb38d5c4985e9e1e3e6" } = {}) {
+  const key = process.env.FISHAUDIO_API_KEY;
+  if (!key) throw new Error("FISHAUDIO_API_KEY is not set");
+  const resp = await fetch("https://api.fish.audio/v1/tts", {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ text, reference_id: referenceId, format: "pcm", sample_rate: 24000, latency: "normal" }),
+  });
+  if (!resp.ok) throw new Error(`FishAudio TTS failed: ${resp.status}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
+async function ttsPcmSakura(text, { model = "zundamon", style = "normal" } = {}) {
+  const key = process.env.SAKURA_API_KEY;
+  if (!key) throw new Error("SAKURA_API_KEY is not set");
+  const resp = await fetch("https://api.ai.sakura.ad.jp/v1/audio/speech", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${key}`,
+      "Content-Type": "application/json",
+      "Accept": "audio/wav",
+    },
+    body: JSON.stringify({ model, input: text, voice: style, response_format: "wav" }),
+  });
+  if (!resp.ok) {
+    const errorText = await resp.text();
+    throw new Error(`Sakura TTS failed: ${resp.status} ${errorText}`);
+  }
+  const wavBuffer = Buffer.from(await resp.arrayBuffer());
+  return wavBuffer.slice(44); // WAVヘッダ(44bytes)をスキップ
+}
+
+// ---- TTS ルーティング ----
+async function generateTTSPcm(text, vendor, voice) {
+  switch (vendor) {
+    case "sakura":     return ttsPcmSakura(text, { model: voice || "zundamon" });
+    case "openai":     return ttsPcmOpenAI(text, { voice: voice || "alloy" });
+    case "google":     return ttsPcmGoogle(text, { voiceName: voice });
+    case "gemini":     return ttsPcmGemini(text, { voiceName: voice || "Kore" });
+    case "elevenlabs": return ttsPcmElevenLabs(text, { voiceId: voice });
+    case "fishaudio":  return ttsPcmFishAudio(text, { referenceId: voice });
+    default:           return ttsPcmSakura(text, { model: "zundamon" });
+  }
+}
+
+// ---- Handler (BUFFEREDモード - isBase64Encodedでバイナリ返却) ----
+export const handler = async (event) => {
+  const start = Date.now();
+  try {
+    const body = event.body ? JSON.parse(event.body) : {};
+    const partialText = body.partial_text ?? "";
+    const characterId = body.character_id ?? null;
+    const history = Array.isArray(body.history) ? body.history.slice(-6) : [];
+    const pastBackchannels = Array.isArray(body.past_backchannels) ? body.past_backchannels.slice(-10) : [];
+
+    if (!partialText) {
+      return { statusCode: 400, body: JSON.stringify({ error: "partial_text is required" }) };
+    }
+
+    // キャラクター設定を解決
+    let ttsVendor = "sakura";
+    let ttsVoice = "zundamon";
+    let personalityPrompt = null;
+
+    if (characterId && characterId !== "default") {
+      const charConfig = await resolveCharacter(characterId);
+      if (charConfig) {
+        const ttsKey = normalizeModelKey(charConfig.provider) ?? TTS_DEFAULT;
+        const cfg = TTS_TABLE[ttsKey] ?? TTS_TABLE[TTS_DEFAULT];
+        ttsVendor = cfg.ttsVendor;
+        ttsVoice = charConfig.vendorId ?? ttsVoice;
+        personalityPrompt = charConfig.personalityPrompt;
+      }
+    }
+
+    // LLM生成
+    const backchannelText = await generateBackchannel(partialText, personalityPrompt, history, pastBackchannels);
+    console.log(`[Backchannel] "${partialText}" → "${backchannelText}" (${Date.now() - start}ms) history=${history.length}turns`);
+
+    // TTS生成 (raw PCM)
+    const ttsStart = Date.now();
+    const pcmBuffer = await generateTTSPcm(backchannelText, ttsVendor, ttsVoice);
+    console.log(`[TTS] ${ttsVendor}/${ttsVoice} pcm=${pcmBuffer.length}bytes (${Date.now() - ttsStart}ms)`);
+    console.log(`[Total] ${Date.now() - start}ms`);
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "X-Backchannel-Text": encodeURIComponent(backchannelText),
+        "X-Pcm-Length": String(pcmBuffer.length),
+        "X-Latency-Ms": String(Date.now() - start),
+      },
+      body: pcmBuffer.toString("base64"),
+      isBase64Encoded: true,
+    };
+  } catch (err) {
+    console.error("[Backchannel] error:", err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: err.message }),
+    };
+  }
+};

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -287,18 +287,19 @@ export const handler = async (event) => {
       return response(200, result.Item);
     }
 
-    // ---- PUT /devices/{device_id} ---- デバイス設定更新（character_id / device_name）
+    // ---- PUT /devices/{device_id} ---- デバイス設定更新（character_id / device_name / backchannel_enabled）
     if (method === "PUT" && path.startsWith("/devices/")) {
       const device_id = decodeURIComponent(path.split("/")[2]);
       const body      = JSON.parse(event.body ?? "{}");
-      const { character_id, device_name } = body;
+      const { character_id, device_name, backchannel_enabled } = body;
 
       const updates = ["last_seen = :t"];
       const vals = { ":t": new Date().toISOString() };
-      if (character_id !== undefined) { updates.push("character_id = :c"); vals[":c"] = character_id; }
-      if (device_name  !== undefined) { updates.push("device_name = :n");  vals[":n"] = device_name; }
-      if (character_id === undefined && device_name === undefined) {
-        return response(400, { error: "character_id or device_name is required" });
+      if (character_id        !== undefined) { updates.push("character_id = :c");        vals[":c"] = character_id; }
+      if (device_name         !== undefined) { updates.push("device_name = :n");         vals[":n"] = device_name; }
+      if (backchannel_enabled !== undefined) { updates.push("backchannel_enabled = :b"); vals[":b"] = backchannel_enabled; }
+      if (character_id === undefined && device_name === undefined && backchannel_enabled === undefined) {
+        return response(400, { error: "character_id, device_name, or backchannel_enabled is required" });
       }
 
       await ddb.send(new UpdateCommand({

--- a/devices/mcu/esp32_s3/mic_test_mini/mic_test_mini.ino
+++ b/devices/mcu/esp32_s3/mic_test_mini/mic_test_mini.ino
@@ -1,0 +1,182 @@
+#include <WiFi.h>
+#include <HTTPClient.h>
+#include <WebSocketsClient.h>
+#include <ArduinoJson.h>
+#include <driver/i2s.h>
+
+// ==== WiFi設定（テスト用ハードコード） ====
+const char* WIFI_SSID     = "Buffalo-G-5830";
+const char* WIFI_PASSWORD = "sh6s3kagpp48s";
+
+// ==== Soniox ====
+const char* SONIOX_LAMBDA_URL = "https://ug5fcnjsxa22vtnrzlwpfgshd40nngbo.lambda-url.ap-northeast-1.on.aws/";
+const char* SONIOX_WS_URL = "stt-rt.soniox.com";
+const int SONIOX_WS_PORT = 443;
+String sonioxKey;
+String sonioxModel = "stt-rt-v4";
+
+// ==== I2S PIN (mini基板) ====
+#define PIN_WS     3
+#define PIN_BCLK   4
+#define PIN_DATA   9
+#define SAMPLE_RATE_STT 16000
+
+// ==== 状態 ====
+WebSocketsClient ws;
+bool isConnected = false;
+bool isRecording = false;
+
+// ==== I2S 録音設定 ====
+void setupI2SRecord() {
+  i2s_config_t cfg = {
+    .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX),
+    .sample_rate = SAMPLE_RATE_STT,
+    .bits_per_sample = I2S_BITS_PER_SAMPLE_32BIT,
+    .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+    .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
+    .intr_alloc_flags = 0,
+    .dma_buf_count = 8,
+    .dma_buf_len = 512,
+    .use_apll = true,
+    .tx_desc_auto_clear = false,
+    .fixed_mclk = 0
+  };
+
+  i2s_pin_config_t pins = {
+    .bck_io_num = PIN_BCLK,
+    .ws_io_num = PIN_WS,
+    .data_out_num = I2S_PIN_NO_CHANGE,
+    .data_in_num = PIN_DATA
+  };
+
+  i2s_driver_install(I2S_NUM_0, &cfg, 0, NULL);
+  i2s_set_pin(I2S_NUM_0, &pins);
+  i2s_start(I2S_NUM_0);
+}
+
+// ==== Soniox WebSocketイベント ====
+void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
+  switch (type) {
+    case WStype_CONNECTED:
+      Serial.println("Connected to Soniox!");
+      {
+        String startMsg =
+          "{\"api_key\":\"" + sonioxKey + "\","
+          "\"model\":\"" + sonioxModel + "\","
+          "\"audio_format\":\"pcm_s16le\","
+          "\"sample_rate\":16000,"
+          "\"num_channels\":1,"
+          "\"enable_partial_results\":true,"
+          "\"enable_endpoint_detection\":true,"
+          "\"language_hints\":[\"ja\",\"en\"]"
+          "}";
+        ws.sendTXT(startMsg);
+        Serial.println("Sent start message");
+      }
+      isRecording = true;
+      break;
+
+    case WStype_TEXT: {
+      String msg = (char*)payload;
+      // シンプルにテキスト部分だけ抽出して表示
+      String text = "";
+      int pos = 0;
+      while ((pos = msg.indexOf("\"text\":\"", pos)) >= 0) {
+        pos += 8;
+        int end = msg.indexOf("\"", pos);
+        if (end < 0) break;
+        String token = msg.substring(pos, end);
+        if (token != "\\u003cend\\u003e") {
+          text += token;
+        }
+      }
+      if (text.length() > 0) {
+        Serial.println(">> " + text);
+      }
+      break;
+    }
+
+    case WStype_DISCONNECTED:
+      Serial.println("Soniox disconnected");
+      isRecording = false;
+      break;
+
+    default:
+      break;
+  }
+}
+
+void setup() {
+  Serial.begin(921600);
+  delay(100);
+  Serial.println("\n=== Mic Test (Mini) ===");
+
+  // WiFi接続
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+  Serial.print("Connecting WiFi");
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.printf("\nWiFi connected! RSSI=%d\n", WiFi.RSSI());
+
+  // Soniox temp key取得
+  HTTPClient http;
+  http.begin(SONIOX_LAMBDA_URL);
+  int code = http.GET();
+  if (code != 200) {
+    Serial.printf("HTTP fail %d\n", code);
+    return;
+  }
+  String resp = http.getString();
+  http.end();
+
+  DynamicJsonDocument doc(512);
+  if (deserializeJson(doc, resp)) {
+    Serial.println("JSON parse error");
+    return;
+  }
+  sonioxKey = doc["api_key"].as<String>();
+  if (doc.containsKey("stt_model")) {
+    sonioxModel = doc["stt_model"].as<String>();
+  }
+  Serial.printf("Soniox key obtained, model=%s\n", sonioxModel.c_str());
+
+  // I2S録音設定
+  setupI2SRecord();
+  Serial.println("I2S ready");
+
+  // Soniox WebSocket接続
+  ws.beginSSL(SONIOX_WS_URL, SONIOX_WS_PORT, "/transcribe-websocket");
+  ws.onEvent(webSocketEvent);
+  Serial.println("Connecting to Soniox...");
+}
+
+void loop() {
+  ws.loop();
+
+  if (isRecording && ws.isConnected()) {
+    static uint32_t lastSend = 0;
+    static uint32_t sendOk = 0, sendFail = 0;
+    static uint32_t lastStats = 0;
+    if (millis() - lastSend > 5) {
+      int32_t raw[512];
+      int16_t pcm[512];
+      size_t n = 0;
+      i2s_read(I2S_NUM_0, (void*)raw, sizeof(raw), &n, portMAX_DELAY);
+      int samples = n / sizeof(int32_t);
+      for (int i = 0; i < samples; i++) {
+        pcm[i] = (int16_t)(raw[i] >> 14);
+      }
+      bool ok = ws.sendBIN((uint8_t*)pcm, samples * sizeof(int16_t));
+      if (ok) sendOk++; else sendFail++;
+      lastSend = millis();
+    }
+    if (millis() - lastStats > 5000) {
+      Serial.printf("[STT] send ok=%d fail=%d RSSI=%d\n", sendOk, sendFail, WiFi.RSSI());
+      sendOk = 0; sendFail = 0;
+      lastStats = millis();
+    }
+  }
+}

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -565,7 +565,7 @@ void setupI2SPlay() {
     .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
     .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
     .intr_alloc_flags = 0,
-    .dma_buf_count = 32,
+    .dma_buf_count = 8,
     .dma_buf_len = 1024,
     .use_apll = true,
     .tx_desc_auto_clear = true,
@@ -1235,24 +1235,26 @@ void sendToLambdaAndPlay(const String& text) {
     }
   }
 
+  unsigned long tEnd = millis();
+
   if (bargeInRequested) {
     Serial.println("🔘 Barge-in: skipping buffer flush");
   } else {
-    // 無音データでDMAバッファをフラッシュ（決め打ちdelayの代わり）
-    Serial.println("🔊 Flushing DMA buffer with silence...");
-    const size_t dmaBytes = 32 * 1024 * 2 * 2; // dma_buf_count * dma_buf_len * 16bit * stereo
+    // 無音データでDMAバッファをフラッシュ（dma_buf_count=8に合わせた軽量版）
+    const size_t dmaBytes = 8 * 1024 * 2 * 2; // dma_buf_count * dma_buf_len * 16bit * stereo
     uint8_t* silence = (uint8_t*)calloc(1, dmaBytes);
     if (silence) {
       size_t written = 0;
       i2s_write(I2S_NUM_1, silence, dmaBytes, &written, portMAX_DELAY);
       free(silence);
     }
-    Serial.println("🔊 Playback complete");
+    Serial.printf("⏱️ end+[%lums] DMA flush (%d bytes)\n", millis() - tEnd, dmaBytes);
   }
 
   // アンプOFF＋次回ソフトスタートのためフラグリセット
   digitalWrite(PIN_AMP_SD, LOW);
   ampOn = false;
+  Serial.printf("⏱️ end+[%lums] Amp off\n", millis() - tEnd);
 
   // barge-in時でも会話履歴は残す（途中でも会話は継続中）
   addToHistory("user", text);
@@ -1262,11 +1264,14 @@ void sendToLambdaAndPlay(const String& text) {
 
   bargeInRequested = false;
   clearBackchannelCache();
+  Serial.printf("⏱️ end+[%lums] Cleanup done\n", millis() - tEnd);
 
   i2s_stop(I2S_NUM_1);
   i2s_driver_uninstall(I2S_NUM_1);
+  Serial.printf("⏱️ end+[%lums] I2S uninstalled\n", millis() - tEnd);
 
   startSTTRecording();
+  Serial.printf("⏱️ end+[%lums] STT recording started\n", millis() - tEnd);
 }
 
 // ==== Soniox WebSocketイベント ====
@@ -1361,16 +1366,19 @@ void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
 
 // ==== STT録音開始 ====
 void startSTTRecording() {
+  unsigned long tRec = millis();
   Serial.println("🎙️ Starting STT recording...");
 
   // 録音準備中はLED点灯（WebSocket接続後にふわふわに変わる）
   setLEDMode(LED_ON);
 
   setupI2SRecord();
+  Serial.printf("⏱️ rec+[%lums] I2S record setup\n", millis() - tRec);
 
   ws.beginSSL(SONIOX_WS_URL, SONIOX_WS_PORT, "/transcribe-websocket");
   ws.onEvent(webSocketEvent);
   ws.enableHeartbeat(15000, 3000, 2);
+  Serial.printf("⏱️ rec+[%lums] Soniox WS begin\n", millis() - tRec);
 
   partialText = "";
   sonioxFinalBuf = "";
@@ -1646,7 +1654,7 @@ void loop() {
       int32_t raw[512];
       int16_t pcm[512];
       size_t n = 0;
-      i2s_read(I2S_NUM_0, (void*)raw, sizeof(raw), &n, pdMS_TO_TICKS(10));
+      i2s_read(I2S_NUM_0, (void*)raw, sizeof(raw), &n, portMAX_DELAY);
       int samples = n / sizeof(int32_t);
       for (int i = 0; i < samples; i++) {
         pcm[i] = (int16_t)(raw[i] >> 14);

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -1025,23 +1025,6 @@ bool playBackchannelIfReady() {
 
   Serial.printf("[BC] Playing backchannel: %d bytes\n", backchannelPcmSize);
 
-  // デバッグ: 先頭16バイトを表示（PCMかbase64テキストか判別）
-  size_t debugLen = min((size_t)16, backchannelPcmSize);
-  Serial.printf("[BC] First %d bytes (hex):", debugLen);
-  for (size_t i = 0; i < debugLen; i++) {
-    Serial.printf(" %02X", backchannelPcm[i]);
-  }
-  Serial.println();
-  // ASCII表示（base64テキストならここで読める）
-  char debugAscii[17] = {};
-  memcpy(debugAscii, backchannelPcm, debugLen);
-  debugAscii[debugLen] = '\0';
-  Serial.printf("[BC] First bytes (ascii): %s\n", debugAscii);
-
-  // I2S再生設定（録音→再生の切り替え）
-  i2s_driver_uninstall(I2S_NUM_0);
-  setupI2SPlay();
-
   // アンプON（ソフトスタート）
   if (!ampOn) {
     ledcAttach(PIN_AMP_SD, 1000, 8);
@@ -1119,15 +1102,11 @@ void sendToLambdaAndPlay(const String& text) {
     }
   }
 
-  // 相槌が準備できていたら先に再生（I2S切り替え含む）
-  bool bcPlayed = playBackchannelIfReady();
+  // I2S切り替え（録音→再生）
+  i2s_driver_uninstall(I2S_NUM_0);
+  setupI2SPlay();
 
-  if (!bcPlayed) {
-    // 相槌再生しなかった場合のみI2S切り替え
-    i2s_driver_uninstall(I2S_NUM_0);
-    setupI2SPlay();
-  }
-
+  // ① 本Lambdaに先に接続＋リクエスト送信（Lambda側の処理を先に開始させる）
   Serial.printf("💾 Free heap before Lambda connect: %d\n", ESP.getFreeHeap());
 
   WiFiClientSecure client;
@@ -1137,7 +1116,6 @@ void sendToLambdaAndPlay(const String& text) {
     Serial.println("❌ connect failed");
     Serial.printf("💾 Free heap at failure: %d\n", ESP.getFreeHeap());
     setLEDMode(LED_OFF);
-    // I2S復帰してSTT再開
     i2s_stop(I2S_NUM_1);
     i2s_driver_uninstall(I2S_NUM_1);
     if (ampOn) { digitalWrite(PIN_AMP_SD, LOW); ampOn = false; }
@@ -1176,7 +1154,25 @@ void sendToLambdaAndPlay(const String& text) {
     + payload;
 
   client.print(req);
+  Serial.println("📨 Request sent, Lambda processing...");
 
+  // ② 相槌再生（本Lambdaが処理している間に再生）
+  // 再生直前に本Lambdaのデータが既に来ていたら相槌スキップ
+  if (backchannelReady && backchannelPcm && backchannelPcmSize > 0) {
+    if (client.available()) {
+      Serial.println("[BC] Main Lambda already responding, skipping backchannel");
+      // 相槌キャッシュ解放
+      free(backchannelPcm);
+      backchannelPcm = NULL;
+      backchannelPcmSize = 0;
+      backchannelReady = false;
+    } else {
+      Serial.println("[BC] Playing backchannel while Lambda processes...");
+      playBackchannelIfReady();
+    }
+  }
+
+  // ③ HTTPレスポンスヘッダー読み取り
   while (true) {
     String line = client.readStringUntil('\n');
     if (line.length() == 0 || line == "\r") break;

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -1064,15 +1064,30 @@ bool playBackchannelIfReady() {
   return true;
 }
 
+// ---- Lambda SSL接続バックグラウンドタスク ----
+struct LambdaConnectParams {
+  WiFiClientSecure* client;
+  volatile bool done;
+  volatile bool ok;
+};
+
+void lambdaConnectTask(void* param) {
+  LambdaConnectParams* p = (LambdaConnectParams*)param;
+  p->client->setInsecure();
+  p->ok = p->client->connect(LAMBDA_HOST, 443);
+  p->done = true;
+  vTaskDelete(NULL);
+}
+
 // ==== Lambda に送信 & SSE 受信 ====
 void sendToLambdaAndPlay(const String& text) {
+  unsigned long t0 = millis();
   Serial.println("🚀 Sending to Lambda: " + text);
   Serial.printf("💾 Free heap: %d bytes\n", ESP.getFreeHeap());
   responseText = "";
 
   if (isRecording) {
     isRecording = false;
-    Serial.println("🛑 Stopped recording");
   }
 
   // バックチャネルタスクがまだ動いている場合、完了を待つ（相槌を再生するため）
@@ -1092,24 +1107,38 @@ void sendToLambdaAndPlay(const String& text) {
       backchannelAbort = false;
     }
   }
+  Serial.printf("⏱️ [%lums] BC wait done\n", millis() - t0);
 
   // I2S切り替え（録音→再生）
   i2s_driver_uninstall(I2S_NUM_0);
   setupI2SPlay();
+  Serial.printf("⏱️ [%lums] I2S switched\n", millis() - t0);
 
   // Soniox WebSocket切断（SSL解放でヒープ確保）
-  unsigned long wsStart = millis();
   ws.disconnect();
-  Serial.printf("🔌 WS disconnect: %lums\n", millis() - wsStart);
+  Serial.printf("⏱️ [%lums] WS disconnected\n", millis() - t0);
 
-  // ① 本Lambdaに先に接続＋リクエスト送信（Lambda側の処理を先に開始させる）
-  Serial.printf("💾 Free heap before Lambda connect: %d\n", ESP.getFreeHeap());
-
+  // ① Lambda SSL接続をCore 0でバックグラウンド開始
   WiFiClientSecure client;
-  client.setInsecure();
+  LambdaConnectParams connParams = { &client, false, false };
+  TaskHandle_t connTaskHandle = NULL;
+  xTaskCreatePinnedToCore(lambdaConnectTask, "lambda_conn", 16384, &connParams, 1, &connTaskHandle, 0);
+  Serial.printf("⏱️ [%lums] Lambda connect task started on Core 0\n", millis() - t0);
 
-  if (!client.connect(LAMBDA_HOST, 443)) {
-    Serial.println("❌ connect failed");
+  // ② 相槌を即座に再生（Lambda接続と並列）
+  if (backchannelReady && backchannelPcm && backchannelPcmSize > 0) {
+    Serial.println("[BC] Playing backchannel while Lambda connects...");
+    playBackchannelIfReady();
+  }
+  Serial.printf("⏱️ [%lums] Backchannel phase done\n", millis() - t0);
+
+  // ③ Lambda接続完了を待つ
+  while (!connParams.done) {
+    delay(1);
+  }
+  Serial.printf("⏱️ [%lums] Lambda connected (ok=%d)\n", millis() - t0, connParams.ok);
+
+  if (!connParams.ok) {
     Serial.printf("💾 Free heap at failure: %d\n", ESP.getFreeHeap());
     setLEDMode(LED_OFF);
     i2s_stop(I2S_NUM_1);
@@ -1120,6 +1149,7 @@ void sendToLambdaAndPlay(const String& text) {
     return;
   }
 
+  // ④ リクエスト送信
   String messagesJson = "[";
   for (int i = 0; i < historyCount; i++) {
     if (i > 0) messagesJson += ",";
@@ -1150,23 +1180,7 @@ void sendToLambdaAndPlay(const String& text) {
     + payload;
 
   client.print(req);
-  Serial.println("📨 Request sent, Lambda processing...");
-
-  // ② 相槌再生（本Lambdaが処理している間に再生）
-  // 再生直前に本Lambdaのデータが既に来ていたら相槌スキップ
-  if (backchannelReady && backchannelPcm && backchannelPcmSize > 0) {
-    if (client.available()) {
-      Serial.println("[BC] Main Lambda already responding, skipping backchannel");
-      // 相槌キャッシュ解放
-      free(backchannelPcm);
-      backchannelPcm = NULL;
-      backchannelPcmSize = 0;
-      backchannelReady = false;
-    } else {
-      Serial.println("[BC] Playing backchannel while Lambda processes...");
-      playBackchannelIfReady();
-    }
-  }
+  Serial.printf("⏱️ [%lums] Request sent\n", millis() - t0);
 
   // ③ HTTPレスポンスヘッダー読み取り
   while (true) {
@@ -1174,6 +1188,7 @@ void sendToLambdaAndPlay(const String& text) {
     if (line.length() == 0 || line == "\r") break;
   }
 
+  Serial.printf("⏱️ [%lums] Headers read, first audio byte incoming\n", millis() - t0);
   Serial.println("📨 BINARY STREAM START (Chunked)");
 
   g_currentChunkSize = -1;

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -59,6 +59,7 @@ const char* SONIOX_LAMBDA_URL = "https://ug5fcnjsxa22vtnrzlwpfgshd40nngbo.lambda
 const char* SONIOX_WS_URL = "stt-rt.soniox.com";
 const int SONIOX_WS_PORT = 443;
 String sonioxKey;
+String sonioxModel = "stt-rt-v4";
 
 // ==== I2S PIN ====
 #define PIN_WS     3
@@ -1105,6 +1106,9 @@ void sendToLambdaAndPlay(const String& text) {
   }
   Serial.printf("⏱️ [%lums] BC wait done\n", millis() - t0);
 
+  // タイマー割り込み再開（再生中のLEDアニメーション用）
+  timerAlarm(ledTimer, 30000, true, 0);
+
   // I2S切り替え（録音→再生）
   i2s_driver_uninstall(I2S_NUM_0);
   setupI2SPlay();
@@ -1289,7 +1293,7 @@ void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
       {
         String startMsg =
           "{\"api_key\":\"" + sonioxKey + "\","
-          "\"model\":\"stt-rt-v3\","
+          "\"model\":\"" + sonioxModel + "\","
           "\"audio_format\":\"pcm_s16le\","
           "\"sample_rate\":16000,"
           "\"num_channels\":1,"
@@ -1299,8 +1303,9 @@ void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
           "}";
         ws.sendTXT(startMsg);
         Serial.println("📤 Sent start message to Soniox");
-        // 録音開始 = LEDふわふわ
-        setLEDMode(LED_BREATHING);
+        // 録音中はタイマー割り込みを停止（I2S競合回避）
+        timerAlarm(ledTimer, 0, false, 0);
+        setLEDMode(LED_ON);
       }
       isRecording = true;
       break;
@@ -1501,7 +1506,10 @@ void startNormalOperation() {
   if (doc.containsKey("backchannel_enabled")) {
     backchannelEnabled = doc["backchannel_enabled"].as<bool>();
   }
-  Serial.printf("🔊 Backchannel: %s\n", backchannelEnabled ? "ON" : "OFF");
+  if (doc.containsKey("stt_model")) {
+    sonioxModel = doc["stt_model"].as<String>();
+  }
+  Serial.printf("🔊 Backchannel: %s, STT: %s\n", backchannelEnabled ? "ON" : "OFF", sonioxModel.c_str());
 
 #if DEBUG_MEMORY
   printMemoryStatus("After WiFi & Soniox Init");
@@ -1663,6 +1671,8 @@ void loop() {
   // 録音データをWebSocketに送信
   if (isRecording && wifiGotIP && ws.isConnected()) {
     static uint32_t lastSend = 0;
+    static uint32_t sendOk = 0, sendFail = 0;
+    static uint32_t lastStats = 0;
     if (millis() - lastSend > 5) {
       int32_t raw[512];
       int16_t pcm[512];
@@ -1672,8 +1682,14 @@ void loop() {
       for (int i = 0; i < samples; i++) {
         pcm[i] = (int16_t)(raw[i] >> 14);
       }
-      ws.sendBIN((uint8_t*)pcm, samples * sizeof(int16_t));
+      bool ok = ws.sendBIN((uint8_t*)pcm, samples * sizeof(int16_t));
+      if (ok) sendOk++; else sendFail++;
       lastSend = millis();
+    }
+    if (millis() - lastStats > 5000) {
+      Serial.printf("[STT] send ok=%d fail=%d RSSI=%d\n", sendOk, sendFail, WiFi.RSSI());
+      sendOk = 0; sendFail = 0;
+      lastStats = millis();
     }
   }
 

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -132,6 +132,7 @@ uint8_t* currentPcmBuffer = NULL;
 size_t currentPcmSize = 0;
 
 // ==== 相槌（Backchannel）状態 ====
+bool backchannelEnabled = true;  // サーバーから取得（起動時）
 const int BACKCHANNEL_TRIGGER_CHARS = 10;  // UTF-8文字数（バイト数ではない）
 
 // UTF-8文字数カウント
@@ -985,6 +986,7 @@ void fetchBackchannelTask(void* param) {
 
 // ==== 相槌フェッチ開始 ====
 void startBackchannelFetch(const String& partial) {
+  if (!backchannelEnabled) return;
   if (backchannelFetching || backchannelReady || backchannelFired) return;
   if (strlen(BACKCHANNEL_HOST) == 0) return;
   // SSL接続に最低50KB必要
@@ -1474,9 +1476,10 @@ void startNormalOperation() {
   Serial.println("🎯 Starting normal operation...");
   currentMode = MODE_NORMAL;
 
-  // Soniox temp key取得
+  // Soniox temp key取得 + デバイス設定
   HTTPClient http;
-  http.begin(SONIOX_LAMBDA_URL);
+  String initUrl = String(SONIOX_LAMBDA_URL) + "?device_id=" + deviceMacAddress;
+  http.begin(initUrl);
   int code = http.GET();
   if (code != 200) {
     Serial.printf("❌ HTTP fail %d\n", code);
@@ -1494,6 +1497,11 @@ void startNormalOperation() {
   }
   sonioxKey = doc["api_key"].as<String>();
   Serial.println("✅ Soniox temp key obtained");
+
+  if (doc.containsKey("backchannel_enabled")) {
+    backchannelEnabled = doc["backchannel_enabled"].as<bool>();
+  }
+  Serial.printf("🔊 Backchannel: %s\n", backchannelEnabled ? "ON" : "OFF");
 
 #if DEBUG_MEMORY
   printMemoryStatus("After WiFi & Soniox Init");

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -132,7 +132,7 @@ uint8_t* currentPcmBuffer = NULL;
 size_t currentPcmSize = 0;
 
 // ==== 相槌（Backchannel）状態 ====
-const int BACKCHANNEL_TRIGGER_CHARS = 5;  // UTF-8文字数（バイト数ではない）
+const int BACKCHANNEL_TRIGGER_CHARS = 10;  // UTF-8文字数（バイト数ではない）
 
 // UTF-8文字数カウント
 int utf8Len(const String& s) {
@@ -882,8 +882,8 @@ void fetchBackchannelTask(void* param) {
 
   String url = String("https://") + BACKCHANNEL_HOST + BACKCHANNEL_PATH;
   String payload = "{\"partial_text\":\"" + partial + "\"";
-  if (charId.length() > 0 && charId != "default") {
-    payload += ",\"character_id\":\"" + charId + "\"";
+  if (charId.length() > 0) {
+    payload += ",\"device_id\":\"" + charId + "\"";
   }
   // 会話履歴（直近6ターン）
   if (historyCount > 0) {

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -1071,9 +1071,8 @@ void sendToLambdaAndPlay(const String& text) {
   responseText = "";
 
   if (isRecording) {
-    ws.disconnect();
     isRecording = false;
-    Serial.println("🛑 Stopped recording for TTS");
+    Serial.println("🛑 Stopped recording");
   }
 
   // バックチャネルタスクがまだ動いている場合、完了を待つ（相槌を再生するため）
@@ -1097,6 +1096,11 @@ void sendToLambdaAndPlay(const String& text) {
   // I2S切り替え（録音→再生）
   i2s_driver_uninstall(I2S_NUM_0);
   setupI2SPlay();
+
+  // Soniox WebSocket切断（SSL解放でヒープ確保）
+  unsigned long wsStart = millis();
+  ws.disconnect();
+  Serial.printf("🔌 WS disconnect: %lums\n", millis() - wsStart);
 
   // ① 本Lambdaに先に接続＋リクエスト送信（Lambda側の処理を先に開始させる）
   Serial.printf("💾 Free heap before Lambda connect: %d\n", ESP.getFreeHeap());

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -1,0 +1,1636 @@
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <WebSocketsClient.h>
+#include <ArduinoJson.h>
+#include <driver/i2s.h>
+#include <esp_wifi.h>
+#include <BLEDevice.h>                                   
+#include <BLEServer.h>
+#include <BLEUtils.h>
+#include <BLE2902.h>
+#include <Preferences.h>
+
+// ==== デバッグ設定 ====
+#define DEBUG_MEMORY 0  // メモリ診断を有効化する場合は1に設定
+
+// ==== WiFi（NVSから読み込み） ====
+String wifiSSID = "";
+String wifiPassword = "";
+String pendingSSID = "";
+String pendingPassword = "";
+Preferences preferences;
+
+// ==== BLE UUIDs（アプリ側toy.tsxと一致） ====
+#define SERVICE_UUID           "12345678-1234-1234-1234-123456789abc"
+#define CHAR_SSID_UUID         "12345678-1234-1234-1234-123456789ab1"
+#define CHAR_PASSWORD_UUID     "12345678-1234-1234-1234-123456789ab2"
+#define CHAR_COMMAND_UUID      "12345678-1234-1234-1234-123456789ab3"
+#define CHAR_STATUS_UUID       "12345678-1234-1234-1234-123456789ab4"
+#define CHAR_MAC_UUID          "12345678-1234-1234-1234-123456789ab5"
+
+// ==== デバイスモード ====
+enum DeviceMode {
+  MODE_NORMAL,      // 通常動作（会話機能）
+  MODE_BLE_PROV,    // BLEプロビジョニング
+  MODE_CONNECTING   // WiFi接続中
+};
+DeviceMode currentMode = MODE_CONNECTING;
+
+// ==== BLE ====
+BLEServer* pServer = NULL;
+BLECharacteristic* pStatusChar = NULL;
+bool bleDeviceConnected = false;
+bool oldBleDeviceConnected = false;
+String deviceMacAddress = "";
+
+// ==== Lambda (TTS) - Binary Streaming ====
+const char* LAMBDA_HOST = "koufofwm3w4tidbe52crbyhpyq0cshss.lambda-url.ap-northeast-1.on.aws";
+const char* LAMBDA_PATH = "/";
+
+// ==== Lambda (Backchannel) ====
+const char* BACKCHANNEL_HOST = "birb7yjw4nkldidcza4xfiyn5e0taluh.lambda-url.ap-northeast-1.on.aws";
+const char* BACKCHANNEL_PATH = "/";
+
+// ==== Lambda (Soniox Key) ====
+const char* SONIOX_LAMBDA_URL = "https://ug5fcnjsxa22vtnrzlwpfgshd40nngbo.lambda-url.ap-northeast-1.on.aws/";
+
+// ==== Soniox ====
+const char* SONIOX_WS_URL = "stt-rt.soniox.com";
+const int SONIOX_WS_PORT = 443;
+String sonioxKey;
+
+// ==== I2S PIN ====
+#define PIN_WS     3
+#define PIN_BCLK   4
+#define PIN_DATA   9
+#define PIN_DOUT   5
+#define PIN_AMP_SD 6
+#define SAMPLE_RATE_STT 16000
+#define SAMPLE_RATE_TTS 24000
+
+
+// ==== LED & Button ====
+#define PIN_LED    8
+#define PIN_BUTTON 7
+#define LED_CHANNEL 0
+#define LED_FREQ 5000
+#define LED_RESOLUTION 8
+
+// LED状態
+enum LEDMode {
+  LED_OFF,
+  LED_ON,
+  LED_BREATHING,  // ふわふわ（録音中）
+  LED_BLINKING    // 点滅（再生中）
+};
+
+LEDMode currentLEDMode = LED_OFF;
+unsigned long lastLEDUpdate = 0;
+int breathingValue = 0;
+bool breathingUp = true;
+bool blinkState = false;
+bool ampOn = false;  // アンプON状態管理（ソフトスタート用）
+volatile bool bargeInRequested = false;  // 再生中のbarge-in（ボタン割り込み）フラグ
+
+// Barge-in用ISR（ボタン押下の瞬間にフラグを立てる）
+void IRAM_ATTR onBargeInButton() {
+  bargeInRequested = true;
+}
+
+// ボタン状態
+int lastButtonReading = HIGH;
+int buttonState = HIGH;
+int lastButtonState = HIGH;
+unsigned long lastDebounceTime = 0;
+const unsigned long debounceDelay = 50;
+
+// ボタン長押し（BLEモード切替用）
+unsigned long buttonPressStart = 0;
+bool buttonLongPressTriggered = false;
+const unsigned long LONG_PRESS_MS = 3000;
+
+// ==== WiFi接続状態（イベントベース） ====
+volatile bool wifiConnected = false;
+volatile bool wifiGotIP = false;
+
+// ==== Soniox STT 状態 ====
+WebSocketsClient ws;
+String partialText = "";
+String sonioxFinalBuf = "";
+String lastFinalText = "";
+unsigned long lastPartialMs = 0;
+const unsigned long END_SILENCE_MS = 800;
+bool armed = false;
+bool isRecording = false;
+bool endpointDetected = false;  // Sonioxの<end>トークン検出フラグ
+
+// ==== TTS 受信状態 ====
+int curSegmentId = -1;
+String responseText = "";
+uint8_t* currentPcmBuffer = NULL;
+size_t currentPcmSize = 0;
+
+// ==== 相槌（Backchannel）状態 ====
+const int BACKCHANNEL_TRIGGER_CHARS = 5;  // UTF-8文字数（バイト数ではない）
+
+// UTF-8文字数カウント
+int utf8Len(const String& s) {
+  int count = 0;
+  for (int i = 0; i < s.length(); ) {
+    uint8_t c = (uint8_t)s.charAt(i);
+    if (c < 0x80) i += 1;
+    else if (c < 0xE0) i += 2;
+    else if (c < 0xF0) i += 3;
+    else i += 4;
+    count++;
+  }
+  return count;
+}
+volatile bool backchannelFetching = false;
+volatile bool backchannelReady = false;
+volatile bool backchannelFired = false;
+volatile bool backchannelAbort = false;
+uint8_t* backchannelPcm = NULL;
+size_t backchannelPcmSize = 0;
+String backchannelText = "";
+TaskHandle_t backchannelTaskHandle = NULL;
+
+// ==== セッションID（電源ON/OFF単位） ====
+String sessionId = "";
+
+// ==== 会話履歴 (直近5回分) ====
+const int MAX_HISTORY = 5;
+struct Message {
+  String role;
+  String content;
+};
+Message conversationHistory[MAX_HISTORY * 2];
+int historyCount = 0;
+
+// ==== 音量調整 ====
+const float VOLUME = 1.0;
+
+// ==== TTS設定（DynamoDB連携予定）====
+// TTS_PROVIDER候補: "OpenAI" / "Google" / "Gemini" / "ElevenLabs"
+const char* TTS_PROVIDER = "ElevenLabs";
+// TTS_CHARACTER: "default"の場合、各TTSのデフォルトキャラクターを使用
+// ElevenLabs: Sameno（子供向け）, OpenAI: nova, Google: ja-JP-Neural2-C, Gemini: Kore
+const char* TTS_CHARACTER = "default";
+
+// ==== WiFiイベントハンドラ ====
+void WiFiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
+  switch (event) {
+    case ARDUINO_EVENT_WIFI_STA_START:
+      Serial.println("🔷 WiFi: STA started");
+      break;
+    case ARDUINO_EVENT_WIFI_STA_STOP:
+      Serial.println("🔷 WiFi: STA stopped");
+      wifiConnected = false;
+      wifiGotIP = false;
+      break;
+    case ARDUINO_EVENT_WIFI_STA_CONNECTED:
+      Serial.println("🔷 WiFi: Connected to AP!");
+      wifiConnected = true;
+      break;
+    case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
+      Serial.printf("🔷 WiFi: Disconnected, reason: %d\n", info.wifi_sta_disconnected.reason);
+      wifiConnected = false;
+      wifiGotIP = false;
+      // 切断理由の詳細
+      switch (info.wifi_sta_disconnected.reason) {
+        case 2:  Serial.println("   -> AUTH_EXPIRE"); break;
+        case 15: Serial.println("   -> 4WAY_HANDSHAKE_TIMEOUT (wrong password?)"); break;
+        case 201: Serial.println("   -> NO_AP_FOUND"); break;
+        case 202: Serial.println("   -> AUTH_FAIL"); break;
+        default: break;
+      }
+      break;
+    case ARDUINO_EVENT_WIFI_STA_GOT_IP:
+      Serial.printf("🔷 WiFi: Got IP: %s\n", WiFi.localIP().toString().c_str());
+      wifiGotIP = true;
+      break;
+    case ARDUINO_EVENT_WIFI_STA_LOST_IP:
+      Serial.println("🔷 WiFi: Lost IP");
+      wifiGotIP = false;
+      break;
+    default:
+      break;
+  }
+}
+
+// ==== NVS操作 ====
+void saveWiFiCredentials(const String& ssid, const String& password) {
+  preferences.begin("wifi", false);
+  preferences.putString("ssid", ssid);
+  preferences.putString("password", password);
+  preferences.end();
+  Serial.println("💾 WiFi credentials saved to NVS");
+}
+
+void saveDeviceMac(const String& mac) {
+  preferences.begin("device", false);
+  preferences.putString("mac", mac);
+  preferences.end();
+  Serial.printf("💾 Device MAC saved to NVS: %s\n", mac.c_str());
+}
+
+String loadDeviceMac() {
+  preferences.begin("device", true);
+  String mac = preferences.getString("mac", "");
+  preferences.end();
+  return mac;
+}
+
+bool loadWiFiCredentials() {
+  preferences.begin("wifi", true);
+  wifiSSID = preferences.getString("ssid", "");
+  wifiPassword = preferences.getString("password", "");
+  preferences.end();
+
+  if (wifiSSID.length() > 0) {
+    Serial.printf("📂 Loaded WiFi: %s\n", wifiSSID.c_str());
+    return true;
+  }
+  Serial.println("📂 No WiFi credentials in NVS");
+  return false;
+}
+
+// ==== BLEステータス送信 ====
+void sendBLEStatus(const char* status) {
+  if (pStatusChar && bleDeviceConnected) {
+    pStatusChar->setValue(status);
+    pStatusChar->notify();
+    Serial.printf("📤 BLE Status: %s\n", status);
+  }
+}
+
+// ==== 前方宣言 ====
+void tryConnectWiFiFromBLE(const String& ssid, const String& password);
+void startNormalOperation();
+
+// ==== BLEコールバック ====
+class ServerCallbacks : public BLEServerCallbacks {
+  void onConnect(BLEServer* pServer) {
+    bleDeviceConnected = true;
+    Serial.println("📱 BLE Client connected");
+  }
+
+  void onDisconnect(BLEServer* pServer) {
+    bleDeviceConnected = false;
+    Serial.println("📱 BLE Client disconnected");
+    if (currentMode == MODE_BLE_PROV) {
+      pServer->startAdvertising();
+    }
+  }
+};
+
+class SSIDCallbacks : public BLECharacteristicCallbacks {
+  void onWrite(BLECharacteristic* pCharacteristic) {
+    String value = pCharacteristic->getValue().c_str();
+    pendingSSID = value;
+    Serial.printf("📝 Received SSID: %s\n", pendingSSID.c_str());
+  }
+};
+
+class PasswordCallbacks : public BLECharacteristicCallbacks {
+  void onWrite(BLECharacteristic* pCharacteristic) {
+    String value = pCharacteristic->getValue().c_str();
+    pendingPassword = value;
+    Serial.printf("📝 Received Password length: %d\n", pendingPassword.length());
+  }
+};
+
+class CommandCallbacks : public BLECharacteristicCallbacks {
+  void onWrite(BLECharacteristic* pCharacteristic) {
+    String value = pCharacteristic->getValue().c_str();
+    Serial.printf("📝 Received Command: %s\n", value.c_str());
+
+    if (value == "CONNECT") {
+      if (pendingSSID.length() > 0) {
+        tryConnectWiFiFromBLE(pendingSSID, pendingPassword);
+      } else {
+        sendBLEStatus("ERROR:NO_SSID");
+      }
+    }
+  }
+};
+
+// ==== BLE開始 ====
+void startBLE() {
+  Serial.println("🔵 Starting BLE...");
+
+  BLEDevice::init("ToyTalk-Setup");
+  pServer = BLEDevice::createServer();
+  pServer->setCallbacks(new ServerCallbacks());
+
+  BLEService* pService = pServer->createService(SERVICE_UUID);
+
+  // SSIDキャラクタリスティック
+  BLECharacteristic* pSSIDChar = pService->createCharacteristic(
+    CHAR_SSID_UUID,
+    BLECharacteristic::PROPERTY_WRITE
+  );
+  pSSIDChar->setCallbacks(new SSIDCallbacks());
+
+  // Passwordキャラクタリスティック
+  BLECharacteristic* pPasswordChar = pService->createCharacteristic(
+    CHAR_PASSWORD_UUID,
+    BLECharacteristic::PROPERTY_WRITE
+  );
+  pPasswordChar->setCallbacks(new PasswordCallbacks());
+
+  // Commandキャラクタリスティック
+  BLECharacteristic* pCommandChar = pService->createCharacteristic(
+    CHAR_COMMAND_UUID,
+    BLECharacteristic::PROPERTY_WRITE
+  );
+  pCommandChar->setCallbacks(new CommandCallbacks());
+
+  // Statusキャラクタリスティック（Notify）
+  pStatusChar = pService->createCharacteristic(
+    CHAR_STATUS_UUID,
+    BLECharacteristic::PROPERTY_READ | BLECharacteristic::PROPERTY_NOTIFY
+  );
+  pStatusChar->addDescriptor(new BLE2902());
+  pStatusChar->setValue("READY");
+
+  // MACアドレスキャラクタリスティック（Read only）
+  BLECharacteristic* pMacChar = pService->createCharacteristic(
+    CHAR_MAC_UUID,
+    BLECharacteristic::PROPERTY_READ
+  );
+  deviceMacAddress = BLEDevice::getAddress().toString().c_str();
+  pMacChar->setValue(deviceMacAddress.c_str());
+
+  pService->start();
+
+  BLEAdvertising* pAdvertising = BLEDevice::getAdvertising();
+  pAdvertising->addServiceUUID(SERVICE_UUID);
+  pAdvertising->setScanResponse(true);
+  pAdvertising->setMinPreferred(0x06);
+  pAdvertising->setMinPreferred(0x12);
+  BLEDevice::startAdvertising();
+
+  Serial.println("🔵 BLE advertising started - Device name: ToyTalk-Setup");
+  currentMode = MODE_BLE_PROV;
+  setLEDMode(LED_BLINKING);  // BLEモード中は点滅
+}
+
+// ==== BLE停止 ====
+void stopBLE() {
+  Serial.println("🔵 Stopping BLE...");
+  BLEDevice::deinit(true);
+  pServer = NULL;
+  pStatusChar = NULL;
+  bleDeviceConnected = false;
+}
+
+// ==== メモリ診断関数 ====
+#if DEBUG_MEMORY
+void printMemoryStatus(const char* label) {
+  Serial.println("========================================");
+  Serial.printf("[MEMORY] %s\n", label);
+  Serial.println("========================================");
+
+  // 総合メモリ情報
+  Serial.printf("Total Heap:      %7d bytes\n", ESP.getHeapSize());
+  Serial.printf("Free Heap:       %7d bytes\n", ESP.getFreeHeap());
+  Serial.printf("Used Heap:       %7d bytes\n", ESP.getHeapSize() - ESP.getFreeHeap());
+  Serial.println("----------------------------------------");
+
+  // 内部RAM詳細
+  uint32_t internalTotal = heap_caps_get_total_size(MALLOC_CAP_INTERNAL);
+  uint32_t internalFree = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+  uint32_t internalUsed = internalTotal - internalFree;
+  Serial.printf("Internal RAM Total: %7d bytes\n", internalTotal);
+  Serial.printf("Internal RAM Free:  %7d bytes\n", internalFree);
+  Serial.printf("Internal RAM Used:  %7d bytes (%.1f%%)\n",
+                internalUsed, (float)internalUsed / internalTotal * 100);
+  Serial.println("----------------------------------------");
+
+  // PSRAM詳細
+  uint32_t psramTotal = heap_caps_get_total_size(MALLOC_CAP_SPIRAM);
+  uint32_t psramFree = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+  uint32_t psramUsed = psramTotal - psramFree;
+  Serial.printf("PSRAM Total:        %7d bytes\n", psramTotal);
+  Serial.printf("PSRAM Free:         %7d bytes\n", psramFree);
+  Serial.printf("PSRAM Used:         %7d bytes (%.1f%%)\n",
+                psramUsed, (float)psramUsed / psramTotal * 100);
+  Serial.println("========================================\n");
+}
+#endif
+
+// ==== LED制御関数（単色LED）====
+void setLEDMode(LEDMode mode) {
+  if (currentLEDMode == mode) return;
+  currentLEDMode = mode;
+  lastLEDUpdate = millis();
+  breathingValue = 0;
+  breathingUp = true;
+  blinkState = false;
+
+  // 即座に状態を反映
+  switch (mode) {
+    case LED_OFF:
+      ledcWrite(PIN_LED, 0);    // 0=OFF (GPIO LOW)
+      break;
+    case LED_ON:
+      ledcWrite(PIN_LED, 16);
+      break;
+    case LED_BREATHING:
+      breathingValue = 3;
+      ledcWrite(PIN_LED, breathingValue);
+      break;
+    case LED_BLINKING:
+      blinkState = true;
+      ledcWrite(PIN_LED, 16);
+      break;
+  }
+}
+
+// loop()から呼ぶLED更新
+void updateLEDAnimation() {
+  unsigned long now = millis();
+
+  if (currentLEDMode == LED_BREATHING) {
+    // ふわふわ: 30ms毎に明るさ変更
+    if (now - lastLEDUpdate > 30) {
+      lastLEDUpdate = now;
+
+      if (breathingUp) {
+        breathingValue += 5;
+        if (breathingValue >= 16) {
+          breathingValue = 16;
+          breathingUp = false;
+        }
+      } else {
+        breathingValue -= 5;
+        if (breathingValue <= 3) {  // 完全に消さず、3で折り返し
+          breathingValue = 3;
+          breathingUp = true;
+        }
+      }
+
+      ledcWrite(PIN_LED, breathingValue);  // PWM値そのまま
+    }
+  }
+  else if (currentLEDMode == LED_BLINKING) {
+    // 点滅: 300ms毎にON/OFF
+    if (now - lastLEDUpdate > 300) {
+      lastLEDUpdate = now;
+      blinkState = !blinkState;
+      ledcWrite(PIN_LED, blinkState ? 16 : 0);
+    }
+  }
+}
+
+// ==== 会話履歴に追加 ====
+void addToHistory(const String& role, const String& content) {
+  if (historyCount >= MAX_HISTORY * 2) {
+    for (int i = 0; i < historyCount - 2; i++) {
+      conversationHistory[i] = conversationHistory[i + 2];
+    }
+    historyCount -= 2;
+  }
+
+  conversationHistory[historyCount].role = role;
+  conversationHistory[historyCount].content = content;
+  historyCount++;
+
+  Serial.printf("💾 Added to history [%s]: %s\n", role.c_str(), content.c_str());
+}
+
+// ==== mono → stereo 変換（音量調整付き） ====
+void monoToStereo(int16_t* mono, int16_t* stereo, size_t samples) {
+  for (size_t i = 0; i < samples; i++) {
+    int16_t sample = (int16_t)(mono[i] * VOLUME);
+    stereo[2*i]     = sample;
+    stereo[2*i + 1] = sample;
+  }
+}
+
+// ==== I2S 録音設定 (STT) ====
+void setupI2SRecord() {
+  i2s_config_t cfg = {
+    .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX),
+    .sample_rate = SAMPLE_RATE_STT,
+    .bits_per_sample = I2S_BITS_PER_SAMPLE_32BIT,
+    .channel_format = I2S_CHANNEL_FMT_ONLY_LEFT,
+    .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
+    .intr_alloc_flags = 0,
+    .dma_buf_count = 8,
+    .dma_buf_len = 512,
+    .use_apll = true,
+    .tx_desc_auto_clear = false,
+    .fixed_mclk = 0
+  };
+
+  i2s_pin_config_t pins = {
+    .bck_io_num = PIN_BCLK,
+    .ws_io_num = PIN_WS,
+    .data_out_num = I2S_PIN_NO_CHANGE,
+    .data_in_num = PIN_DATA
+  };
+
+  esp_err_t err = i2s_driver_install(I2S_NUM_0, &cfg, 0, NULL);
+  if (err != ESP_OK) {
+    Serial.printf("❌ i2s_driver_install failed: %d\n", err);
+  }
+  err = i2s_set_pin(I2S_NUM_0, &pins);
+  if (err != ESP_OK) {
+    Serial.printf("❌ i2s_set_pin failed: %d\n", err);
+  }
+  i2s_start(I2S_NUM_0);
+}
+
+// ==== I2S 再生設定 (TTS) ====
+void setupI2SPlay() {
+  pinMode(PIN_AMP_SD, OUTPUT);
+  digitalWrite(PIN_AMP_SD, LOW);
+  delay(10);
+
+  i2s_config_t cfg = {
+    .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX),
+    .sample_rate = SAMPLE_RATE_TTS,
+    .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+    .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+    .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
+    .intr_alloc_flags = 0,
+    .dma_buf_count = 32,
+    .dma_buf_len = 1024,
+    .use_apll = true,
+    .tx_desc_auto_clear = true,
+    .fixed_mclk = 0
+  };
+
+  i2s_pin_config_t pins = {
+    .bck_io_num = PIN_BCLK,
+    .ws_io_num = PIN_WS,
+    .data_out_num = PIN_DOUT,
+    .data_in_num = I2S_PIN_NO_CHANGE
+  };
+
+  i2s_driver_install(I2S_NUM_1, &cfg, 0, NULL);
+  i2s_set_pin(I2S_NUM_1, &pins);
+  i2s_set_clk(I2S_NUM_1, SAMPLE_RATE_TTS, I2S_BITS_PER_SAMPLE_16BIT, I2S_CHANNEL_STEREO);
+}
+
+// ==== チャンク管理用グローバル変数 ====
+static int g_currentChunkSize = -1;
+static int g_bytesReadFromChunk = 0;
+
+// ==== HTTPチャンクサイズ読み取り ====
+int readChunkSize(WiFiClientSecure& client) {
+  const int MAX_RETRIES = 3;
+
+  for (int retry = 0; retry < MAX_RETRIES; retry++) {
+    String line = "";
+    unsigned long startTime = millis();
+
+    while (client.connected() && (millis() - startTime < 5000)) {
+      if (client.available()) {
+        char c = client.read();
+        if (c == '\n') {
+          break;
+        } else if (c != '\r') {
+          line += c;
+        }
+      } else {
+        delay(1);
+      }
+    }
+
+    if (line.length() == 0) {
+      Serial.printf("[CHUNK] Read empty line (retry %d/%d)\n", retry + 1, MAX_RETRIES);
+      if (retry < MAX_RETRIES - 1) {
+        delay(100);
+        continue;
+      }
+      return -1;
+    }
+
+    int chunkSize = 0;
+    bool validHex = false;
+    for (int i = 0; i < line.length(); i++) {
+      char c = line.charAt(i);
+      if (c >= '0' && c <= '9') {
+        chunkSize = chunkSize * 16 + (c - '0');
+        validHex = true;
+      } else if (c >= 'a' && c <= 'f') {
+        chunkSize = chunkSize * 16 + (c - 'a' + 10);
+        validHex = true;
+      } else if (c >= 'A' && c <= 'F') {
+        chunkSize = chunkSize * 16 + (c - 'A' + 10);
+        validHex = true;
+      } else {
+        break;
+      }
+    }
+
+    if (!validHex) {
+      Serial.printf("[CHUNK] Invalid hex line: '%s' (retry %d/%d)\n", line.c_str(), retry + 1, MAX_RETRIES);
+      if (retry < MAX_RETRIES - 1) {
+        delay(100);
+        continue;
+      }
+      return -1;
+    }
+
+    Serial.printf("[CHUNK] Size: %d (0x%s)\n", chunkSize, line.c_str());
+    return chunkSize;
+  }
+
+  return -1;
+}
+
+// ==== チャンク境界を超えてデータを読む ====
+size_t readBytesAcrossChunks(WiFiClientSecure& client, uint8_t* buffer, size_t length) {
+  size_t totalRead = 0;
+  unsigned long startTime = millis();
+  const unsigned long TIMEOUT_MS = 10000;
+
+  while (totalRead < length) {
+    if (millis() - startTime > TIMEOUT_MS) {
+      Serial.printf("[READ] Timeout after %d bytes\n", totalRead);
+      return totalRead;
+    }
+
+    if (g_currentChunkSize == -1 || g_bytesReadFromChunk >= g_currentChunkSize) {
+      if (g_currentChunkSize > 0) {
+        while (!client.available() && client.connected() && (millis() - startTime < TIMEOUT_MS)) {
+          delay(1);
+        }
+        client.read();
+        client.read();
+      }
+
+      g_currentChunkSize = readChunkSize(client);
+      g_bytesReadFromChunk = 0;
+
+      if (g_currentChunkSize == 0) {
+        return totalRead;
+      } else if (g_currentChunkSize < 0) {
+        Serial.println("[READ] Chunk read error");
+        return totalRead;
+      }
+    }
+
+    int remainingInChunk = g_currentChunkSize - g_bytesReadFromChunk;
+    int toRead = min((int)(length - totalRead), remainingInChunk);
+
+    while (!client.available() && client.connected() && (millis() - startTime < TIMEOUT_MS)) {
+      delay(1);
+    }
+
+    if (!client.connected() && !client.available()) {
+      Serial.println("[READ] Connection closed");
+      return totalRead;
+    }
+
+    int available = client.available();
+    if (available > 0) {
+      int actualRead = min(toRead, available);
+      size_t read = client.readBytes(buffer + totalRead, actualRead);
+      totalRead += read;
+      g_bytesReadFromChunk += read;
+    }
+  }
+
+  return totalRead;
+}
+
+// ==== バイナリプロトコル: メタデータ処理 (type=0x01) ====
+void processMetadata(WiFiClientSecure& client, uint32_t length) {
+  if (length == 0 || length > 4096) {
+    Serial.printf("[META] Invalid length: %d\n", length);
+    return;
+  }
+
+  char* jsonBuf = (char*)malloc(length + 1);
+  if (!jsonBuf) {
+    Serial.println("[META] malloc failed");
+    return;
+  }
+
+  size_t bytesRead = readBytesAcrossChunks(client, (uint8_t*)jsonBuf, length);
+  jsonBuf[bytesRead] = '\0';
+
+  if (bytesRead != length) {
+    Serial.printf("[META] Read mismatch: expected=%d, got=%d\n", length, bytesRead);
+    free(jsonBuf);
+    return;
+  }
+
+  String json = String(jsonBuf);
+  Serial.printf("[META] %s\n", jsonBuf);
+
+  if (json.indexOf("\"event\":\"segment\"") >= 0) {
+    int p = json.indexOf("\"text\":\"");
+    if (p >= 0) {
+      p += 8;
+      int e = json.indexOf("\"", p);
+      if (e >= 0) {
+        String segmentText = json.substring(p, e);
+        responseText += segmentText;
+        Serial.printf("[SEGMENT] Text: %s\n", segmentText.c_str());
+      }
+    }
+    int idPos = json.indexOf("\"id\":");
+    if (idPos >= 0) {
+      idPos += 5;
+      curSegmentId = json.substring(idPos, json.indexOf(",", idPos)).toInt();
+    }
+  }
+
+  if (json.indexOf("\"event\":\"tts_start\"") >= 0) {
+    int sizePos = json.indexOf("\"size\":");
+    if (sizePos >= 0) {
+      sizePos += 7;
+      currentPcmSize = json.substring(sizePos, json.indexOf("}", sizePos)).toInt();
+      Serial.printf("[TTS_START] id=%d, size=%d\n", curSegmentId, currentPcmSize);
+    }
+  }
+
+  free(jsonBuf);
+}
+
+// ==== バイナリプロトコル: PCMデータ処理 (type=0x02) - ストリーミング版 ====
+// 戻り値: true=barge-in発生（再生中断）, false=正常完了
+bool processPCM(WiFiClientSecure& client, uint32_t length) {
+  // アンプをPWMでゆっくりON（突入電流抑制）
+  if (!ampOn) {
+    ledcAttach(PIN_AMP_SD, 1000, 8);
+    for (int i = 0; i <= 255; i += 5) {
+      ledcWrite(PIN_AMP_SD, i);
+      delay(2);
+    }
+    ledcDetach(PIN_AMP_SD);
+    pinMode(PIN_AMP_SD, OUTPUT);
+    digitalWrite(PIN_AMP_SD, HIGH);
+    delay(50);
+    ampOn = true;
+  }
+  Serial.printf("[PCM] Streaming %d bytes\n", length);
+#if DEBUG_MEMORY
+  printMemoryStatus("Before PCM Processing");
+#endif
+
+  // ストリーミング再生用のバッファ（64KB）
+  const size_t STREAM_CHUNK_SIZE = 65536;
+  uint32_t remaining = length;
+  uint32_t totalPlayed = 0;
+
+  while (remaining > 0) {
+    updateLEDAnimation();
+
+    // === Barge-in チェック（ISRでフラグが立っていれば即中断） ===
+    if (bargeInRequested) {
+      Serial.println("🔘 Barge-in! Stopping playback");
+      return true;
+    }
+
+    uint32_t chunkSize = (remaining > STREAM_CHUNK_SIZE) ? STREAM_CHUNK_SIZE : remaining;
+
+    uint8_t* pcmData = (uint8_t*)ps_malloc(chunkSize);
+    if (!pcmData) {
+      pcmData = (uint8_t*)malloc(chunkSize);
+    }
+    if (!pcmData) {
+      Serial.printf("[PCM] malloc failed for chunk! Skipping remaining %d bytes\n", remaining);
+      uint8_t dummy[512];
+      while (remaining > 0) {
+        uint32_t toRead = (remaining > 512) ? 512 : remaining;
+        size_t read = readBytesAcrossChunks(client, dummy, toRead);
+        if (read == 0) break;
+        remaining -= read;
+      }
+      return false;
+    }
+
+    size_t bytesRead = readBytesAcrossChunks(client, pcmData, chunkSize);
+    if (bytesRead != chunkSize) {
+      Serial.printf("[PCM] Read mismatch in chunk: expected=%d, got=%d\n", chunkSize, bytesRead);
+      free(pcmData);
+      break;
+    }
+
+    size_t samples = bytesRead / 2;
+    size_t stereoBytes = samples * 4;
+    int16_t* stereo = (int16_t*)malloc(stereoBytes);
+    if (!stereo) {
+      Serial.println("[PCM] stereo malloc failed for chunk!");
+      free(pcmData);
+      break;
+    }
+
+    monoToStereo((int16_t*)pcmData, stereo, samples);
+    free(pcmData);
+
+    size_t written = 0;
+    i2s_write(I2S_NUM_1, (uint8_t*)stereo, stereoBytes, &written, portMAX_DELAY);
+    free(stereo);
+
+    totalPlayed += written;
+    remaining -= bytesRead;
+
+    if (totalPlayed % (STREAM_CHUNK_SIZE * 4) == 0) {
+      Serial.printf("[PCM] Streaming... played %d/%d bytes\n", totalPlayed, length * 2);
+    }
+  }
+
+  Serial.printf("[PCM] Streaming complete: %d bytes total\n", totalPlayed);
+  return false;
+}
+
+// ==== 相槌キャッシュクリア ====
+void clearBackchannelCache() {
+  if (backchannelPcm) {
+    free(backchannelPcm);
+    backchannelPcm = NULL;
+  }
+  backchannelPcmSize = 0;
+  backchannelText = "";
+  backchannelReady = false;
+  backchannelFetching = false;
+  backchannelFired = false;
+  backchannelAbort = false;
+}
+
+// ==== 相槌フェッチ用FreeRTOSタスク ====
+struct BackchannelParams {
+  String partialText;
+  String characterId;
+};
+
+void fetchBackchannelTask(void* param) {
+  BackchannelParams* p = (BackchannelParams*)param;
+  String partial = p->partialText;
+  String charId = p->characterId;
+  delete p;
+
+  Serial.printf("[BC] Fetching backchannel for: %s\n", partial.c_str());
+  Serial.printf("[BC] Free heap before: %d\n", ESP.getFreeHeap());
+
+  String url = String("https://") + BACKCHANNEL_HOST + BACKCHANNEL_PATH;
+  String payload = "{\"partial_text\":\"" + partial + "\"";
+  if (charId.length() > 0 && charId != "default") {
+    payload += ",\"character_id\":\"" + charId + "\"";
+  }
+  payload += "}";
+
+  // ブロックスコープでHTTPClientのデストラクタを確実に呼ぶ
+  {
+    HTTPClient http;
+    http.begin(url);
+    http.addHeader("Content-Type", "application/json");
+    http.setTimeout(8000);
+    const char* headerKeys[] = {"X-Backchannel-Text", "x-backchannel-text"};
+    http.collectHeaders(headerKeys, 2);
+
+    int httpCode = http.POST(payload);
+
+    if (backchannelAbort || httpCode != 200) {
+      Serial.printf("[BC] %s (code=%d)\n", backchannelAbort ? "Aborted" : "HTTP error", httpCode);
+      http.end();
+    } else {
+      // ヘッダーからテキスト取得
+      if (http.hasHeader("X-Backchannel-Text")) {
+        backchannelText = http.header("X-Backchannel-Text");
+      } else if (http.hasHeader("x-backchannel-text")) {
+        backchannelText = http.header("x-backchannel-text");
+      }
+
+      // レスポンスボディ = raw PCMバイナリ（BUFFEREDモードでbase64デコード済み）
+      int len = http.getSize();
+      WiFiClient* stream = http.getStreamPtr();
+
+      const size_t INIT_SIZE = 32768;
+      const size_t MAX_SIZE = 256000;
+      size_t bufSize = (len > 0) ? (size_t)len : INIT_SIZE;
+      uint8_t* pcm = (uint8_t*)ps_malloc(bufSize);
+      if (!pcm) pcm = (uint8_t*)malloc(bufSize);
+
+      if (pcm) {
+        size_t totalRead = 0;
+        unsigned long startTime = millis();
+        while (http.connected() && (millis() - startTime < 15000) && !backchannelAbort) {
+          size_t avail = stream->available();
+          if (avail > 0) {
+            if (totalRead + avail > bufSize) {
+              size_t newSize = min(bufSize * 2, MAX_SIZE);
+              if (newSize <= bufSize) break;
+              uint8_t* newBuf = (uint8_t*)ps_realloc(pcm, newSize);
+              if (!newBuf) newBuf = (uint8_t*)realloc(pcm, newSize);
+              if (!newBuf) break;
+              pcm = newBuf;
+              bufSize = newSize;
+            }
+            size_t rd = stream->readBytes(pcm + totalRead, avail);
+            totalRead += rd;
+          } else {
+            if (len > 0 && (int)totalRead >= len) break;
+            delay(1);
+          }
+        }
+
+        if (totalRead > 0 && !backchannelAbort) {
+          backchannelPcm = pcm;
+          backchannelPcmSize = totalRead;
+          backchannelReady = true;
+          Serial.printf("[BC] Ready: pcm=%d bytes\n", totalRead);
+        } else {
+          free(pcm);
+          Serial.printf("[BC] %s\n", backchannelAbort ? "Aborted" : "No PCM data");
+        }
+      } else {
+        Serial.println("[BC] malloc failed");
+      }
+      http.end();
+    }
+  } // HTTPClient デストラクタ実行 → SSL解放
+
+  Serial.printf("[BC] Free heap after: %d\n", ESP.getFreeHeap());
+  backchannelFetching = false;
+  backchannelTaskHandle = NULL;
+  vTaskDelete(NULL);
+}
+
+// ==== 相槌フェッチ開始 ====
+void startBackchannelFetch(const String& partial) {
+  if (backchannelFetching || backchannelReady || backchannelFired) return;
+  if (strlen(BACKCHANNEL_HOST) == 0) return;
+  // SSL接続に最低50KB必要
+  if (ESP.getFreeHeap() < 60000) {
+    Serial.printf("[BC] Not enough heap: %d bytes, skipping\n", ESP.getFreeHeap());
+    return;
+  }
+
+  backchannelFetching = true;
+
+  BackchannelParams* params = new BackchannelParams();
+  params->partialText = partial;
+  params->characterId = deviceMacAddress;  // device_idをcharacter解決に使う
+
+  xTaskCreatePinnedToCore(
+    fetchBackchannelTask,
+    "bc_fetch",
+    16384,
+    params,
+    1,          // 低優先度
+    &backchannelTaskHandle,
+    0           // Core 0（メインループはCore 1）
+  );
+}
+
+// ==== 相槌再生 ====
+// 戻り値: 再生したかどうか
+bool playBackchannelIfReady() {
+  if (!backchannelReady || !backchannelPcm || backchannelPcmSize == 0) return false;
+
+  Serial.printf("[BC] Playing backchannel: %d bytes\n", backchannelPcmSize);
+
+  // デバッグ: 先頭16バイトを表示（PCMかbase64テキストか判別）
+  size_t debugLen = min((size_t)16, backchannelPcmSize);
+  Serial.printf("[BC] First %d bytes (hex):", debugLen);
+  for (size_t i = 0; i < debugLen; i++) {
+    Serial.printf(" %02X", backchannelPcm[i]);
+  }
+  Serial.println();
+  // ASCII表示（base64テキストならここで読める）
+  char debugAscii[17] = {};
+  memcpy(debugAscii, backchannelPcm, debugLen);
+  debugAscii[debugLen] = '\0';
+  Serial.printf("[BC] First bytes (ascii): %s\n", debugAscii);
+
+  // I2S再生設定（録音→再生の切り替え）
+  i2s_driver_uninstall(I2S_NUM_0);
+  setupI2SPlay();
+
+  // アンプON（ソフトスタート）
+  if (!ampOn) {
+    ledcAttach(PIN_AMP_SD, 1000, 8);
+    for (int i = 0; i <= 255; i += 5) {
+      ledcWrite(PIN_AMP_SD, i);
+      delay(2);
+    }
+    ledcDetach(PIN_AMP_SD);
+    pinMode(PIN_AMP_SD, OUTPUT);
+    digitalWrite(PIN_AMP_SD, HIGH);
+    delay(50);
+    ampOn = true;
+  }
+
+  // mono→stereo変換して再生
+  size_t samples = backchannelPcmSize / 2;
+  const size_t PLAY_CHUNK = 4096;
+  size_t offset = 0;
+
+  while (offset < samples) {
+    size_t chunkSamples = min(PLAY_CHUNK, samples - offset);
+    size_t stereoBytes = chunkSamples * 4;
+    int16_t* stereo = (int16_t*)malloc(stereoBytes);
+    if (!stereo) break;
+
+    monoToStereo((int16_t*)(backchannelPcm + offset * 2), stereo, chunkSamples);
+    size_t written = 0;
+    i2s_write(I2S_NUM_1, (uint8_t*)stereo, stereoBytes, &written, portMAX_DELAY);
+    free(stereo);
+    offset += chunkSamples;
+  }
+
+  backchannelFired = true;
+  Serial.println("[BC] Backchannel playback done");
+
+  // PCM解放
+  free(backchannelPcm);
+  backchannelPcm = NULL;
+  backchannelPcmSize = 0;
+  backchannelReady = false;
+
+  return true;
+}
+
+// ==== Lambda に送信 & SSE 受信 ====
+void sendToLambdaAndPlay(const String& text) {
+  Serial.println("🚀 Sending to Lambda: " + text);
+  Serial.printf("💾 Free heap: %d bytes\n", ESP.getFreeHeap());
+  responseText = "";
+
+  if (isRecording) {
+    ws.disconnect();
+    isRecording = false;
+    Serial.println("🛑 Stopped recording for TTS");
+  }
+
+  // バックチャネルタスクがまだ動いている場合、完了を待つ（相槌を再生するため）
+  if (backchannelFetching && backchannelTaskHandle != NULL) {
+    Serial.println("[BC] Waiting for backchannel task to finish...");
+    unsigned long waitStart = millis();
+    while (backchannelTaskHandle != NULL && (millis() - waitStart < 10000)) {
+      delay(10);
+    }
+    if (backchannelTaskHandle != NULL) {
+      Serial.println("[BC] Timeout - aborting task");
+      backchannelAbort = true;
+      unsigned long abortStart = millis();
+      while (backchannelTaskHandle != NULL && (millis() - abortStart < 3000)) {
+        delay(10);
+      }
+      backchannelAbort = false;
+    }
+  }
+
+  // 相槌が準備できていたら先に再生（I2S切り替え含む）
+  bool bcPlayed = playBackchannelIfReady();
+
+  if (!bcPlayed) {
+    // 相槌再生しなかった場合のみI2S切り替え
+    i2s_driver_uninstall(I2S_NUM_0);
+    setupI2SPlay();
+  }
+
+  Serial.printf("💾 Free heap before Lambda connect: %d\n", ESP.getFreeHeap());
+
+  WiFiClientSecure client;
+  client.setInsecure();
+
+  if (!client.connect(LAMBDA_HOST, 443)) {
+    Serial.println("❌ connect failed");
+    Serial.printf("💾 Free heap at failure: %d\n", ESP.getFreeHeap());
+    setLEDMode(LED_OFF);
+    // I2S復帰してSTT再開
+    i2s_stop(I2S_NUM_1);
+    i2s_driver_uninstall(I2S_NUM_1);
+    if (ampOn) { digitalWrite(PIN_AMP_SD, LOW); ampOn = false; }
+    clearBackchannelCache();
+    startSTTRecording();
+    return;
+  }
+
+  String messagesJson = "[";
+  for (int i = 0; i < historyCount; i++) {
+    if (i > 0) messagesJson += ",";
+    messagesJson += "{\"role\":\"" + conversationHistory[i].role + "\",";
+    messagesJson += "\"content\":\"" + conversationHistory[i].content + "\"}";
+  }
+  if (historyCount > 0) messagesJson += ",";
+  messagesJson += "{\"role\":\"user\",\"content\":\"" + text + "\"}";
+  messagesJson += "]";
+
+  String payload =
+    "{\"model\":\"" + String(TTS_PROVIDER) + "\",\"voice\":\"" + String(TTS_CHARACTER) + "\","
+    "\"device_id\":\"" + deviceMacAddress + "\","
+    "\"session_id\":\"" + sessionId + "\","
+    "\"owner_id\":\"" + deviceMacAddress + "\","
+    "\"backchannel_fired\":" + (backchannelFired ? "true" : "false") + ","
+    "\"messages\":" + messagesJson + "}";
+
+  Serial.printf("📝 History count: %d\n", historyCount);
+
+  String req =
+    String("POST ") + LAMBDA_PATH + " HTTP/1.1\r\n"
+    "Host: " + LAMBDA_HOST + "\r\n"
+    "Content-Type: application/json\r\n"
+    "Accept: text/event-stream\r\n"
+    "Connection: close\r\n"
+    "Content-Length: " + payload.length() + "\r\n\r\n"
+    + payload;
+
+  client.print(req);
+
+  while (true) {
+    String line = client.readStringUntil('\n');
+    if (line.length() == 0 || line == "\r") break;
+  }
+
+  Serial.println("📨 BINARY STREAM START (Chunked)");
+
+  g_currentChunkSize = -1;
+  g_bytesReadFromChunk = 0;
+
+  // TTS開始 = 再生中はLED点滅
+  setLEDMode(LED_BLINKING);
+
+  while (client.connected() || client.available()) {
+    uint8_t header[5];
+    size_t read = readBytesAcrossChunks(client, header, 5);
+
+    if (read == 0) {
+      Serial.println("🏁 BINARY STREAM END");
+      break;
+    }
+
+    if (read != 5) {
+      Serial.printf("[BINARY] Header incomplete: %d/5 bytes\n", read);
+      break;
+    }
+
+    uint8_t type = header[0];
+    uint32_t length = (header[1]) | (header[2] << 8) | (header[3] << 16) | (header[4] << 24);
+
+    Serial.printf("[BINARY] type=0x%02X, length=%d\n", type, length);
+
+    if (type == 0x01) {
+      processMetadata(client, length);
+    } else if (type == 0x02) {
+      if (processPCM(client, length)) {
+        Serial.println("🔘 Barge-in: aborting stream");
+        client.stop();
+        break;
+      }
+    } else {
+      Serial.printf("[BINARY] Unknown type: 0x%02X, skip %d bytes\n", type, length);
+      uint8_t* dummy = (uint8_t*)malloc(length);
+      if (dummy) {
+        readBytesAcrossChunks(client, dummy, length);
+        free(dummy);
+      }
+    }
+  }
+
+  if (bargeInRequested) {
+    Serial.println("🔘 Barge-in: skipping buffer flush");
+  } else {
+    // 無音データでDMAバッファをフラッシュ（決め打ちdelayの代わり）
+    Serial.println("🔊 Flushing DMA buffer with silence...");
+    const size_t dmaBytes = 32 * 1024 * 2 * 2; // dma_buf_count * dma_buf_len * 16bit * stereo
+    uint8_t* silence = (uint8_t*)calloc(1, dmaBytes);
+    if (silence) {
+      size_t written = 0;
+      i2s_write(I2S_NUM_1, silence, dmaBytes, &written, portMAX_DELAY);
+      free(silence);
+    }
+    Serial.println("🔊 Playback complete");
+  }
+
+  // アンプOFF＋次回ソフトスタートのためフラグリセット
+  digitalWrite(PIN_AMP_SD, LOW);
+  ampOn = false;
+
+  // barge-in時でも会話履歴は残す（途中でも会話は継続中）
+  addToHistory("user", text);
+  if (responseText.length() > 0) {
+    addToHistory("assistant", responseText);
+  }
+
+  bargeInRequested = false;
+  clearBackchannelCache();
+
+  i2s_stop(I2S_NUM_1);
+  i2s_driver_uninstall(I2S_NUM_1);
+
+  startSTTRecording();
+}
+
+// ==== Soniox WebSocketイベント ====
+void webSocketEvent(WStype_t type, uint8_t *payload, size_t length) {
+  switch (type) {
+    case WStype_CONNECTED:
+      Serial.println("✅ Connected to Soniox!");
+      {
+        String startMsg =
+          "{\"api_key\":\"" + sonioxKey + "\","
+          "\"model\":\"stt-rt-v3\","
+          "\"audio_format\":\"pcm_s16le\","
+          "\"sample_rate\":16000,"
+          "\"num_channels\":1,"
+          "\"enable_partial_results\":true,"
+          "\"enable_endpoint_detection\":true,"
+          "\"language_hints\":[\"ja\",\"en\"]"
+          "}";
+        ws.sendTXT(startMsg);
+        Serial.println("📤 Sent start message to Soniox");
+        // 録音開始 = LEDふわふわ
+        setLEDMode(LED_BREATHING);
+      }
+      isRecording = true;
+      break;
+
+    case WStype_TEXT: {
+      String msg = (char*)payload;
+      if (msg.indexOf("\"tokens\"") >= 0) {
+        String nonFinalCurrent = "";
+        bool foundEndToken = false;
+        int searchPos = msg.indexOf("\"tokens\"");
+        while (true) {
+          int textPos = msg.indexOf("\"text\":\"", searchPos);
+          if (textPos < 0) break;
+          textPos += 8;
+          int textEnd = msg.indexOf("\"", textPos);
+          if (textEnd < 0) break;
+          String token = msg.substring(textPos, textEnd);
+
+          int objEnd = msg.indexOf("}", textEnd);
+          if (objEnd < 0) objEnd = msg.length();
+          String objSlice = msg.substring(textEnd, objEnd);
+          bool isFinal = objSlice.indexOf("\"is_final\":true") >= 0;
+
+          if (token == "\\u003cend\\u003e") {
+            foundEndToken = true;
+          } else if (isFinal) {
+            sonioxFinalBuf += token;
+          } else {
+            nonFinalCurrent += token;
+          }
+          searchPos = textEnd + 1;
+        }
+
+        String fullText = sonioxFinalBuf + nonFinalCurrent;
+        if (fullText.length() > 0) {
+          partialText = fullText;
+          lastPartialMs = millis();
+          armed = true;
+          Serial.println("📝 " + partialText);
+
+          // 相槌トリガー: 閾値文字数（UTF-8）に達したらバックグラウンドでフェッチ開始
+          if (utf8Len(fullText) >= BACKCHANNEL_TRIGGER_CHARS && !backchannelFired && !backchannelFetching && !backchannelReady) {
+            startBackchannelFetch(fullText);
+          }
+        }
+
+        // <end>トークン検出時、即座に確定
+        if (foundEndToken && partialText.length() > 0) {
+          Serial.println("🎯 Endpoint detected by Soniox!");
+          endpointDetected = true;
+        }
+      }
+      break;
+    }
+
+    case WStype_DISCONNECTED:
+      Serial.println("✅ Soniox disconnected");
+      isRecording = false;
+      break;
+
+    case WStype_BIN:
+    case WStype_ERROR:
+    case WStype_FRAGMENT_TEXT_START:
+    case WStype_FRAGMENT_BIN_START:
+    case WStype_FRAGMENT:
+    case WStype_FRAGMENT_FIN:
+      break;
+  }
+}
+
+// ==== STT録音開始 ====
+void startSTTRecording() {
+  Serial.println("🎙️ Starting STT recording...");
+
+  // 録音準備中はLED点灯（WebSocket接続後にふわふわに変わる）
+  setLEDMode(LED_ON);
+
+  setupI2SRecord();
+
+  ws.beginSSL(SONIOX_WS_URL, SONIOX_WS_PORT, "/transcribe-websocket");
+  ws.onEvent(webSocketEvent);
+  ws.enableHeartbeat(15000, 3000, 2);
+
+  partialText = "";
+  sonioxFinalBuf = "";
+  lastFinalText = "";
+  armed = false;
+  endpointDetected = false;
+  clearBackchannelCache();
+}
+
+// ==== WiFi接続（1回試行）- Country=JP対応 ====
+bool tryConnectWiFiOnce(const String& ssid, const String& password) {
+  wifiConnected = false;
+  wifiGotIP = false;
+
+  WiFi.disconnect(true);
+  delay(500);
+  WiFi.mode(WIFI_STA);
+  delay(100);
+
+  // iPhoneホットスポット対応: Country=JP設定
+  wifi_country_t country = {
+    .cc = "JP",
+    .schan = 1,
+    .nchan = 14,
+    .max_tx_power = 20,
+    .policy = WIFI_COUNTRY_POLICY_MANUAL
+  };
+  esp_wifi_set_country(&country);
+
+  Serial.printf("📶 Connecting to: %s\n", ssid.c_str());
+  WiFi.begin(ssid.c_str(), password.c_str());
+
+  // 最大10秒待機
+  for (int i = 0; i < 10; i++) {
+    delay(1000);
+    Serial.print(".");
+    if (wifiGotIP) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// ==== BLEからのWiFi接続試行 ====
+void tryConnectWiFiFromBLE(const String& ssid, const String& password) {
+  Serial.printf("📶 Connecting to WiFi from BLE: %s\n", ssid.c_str());
+  sendBLEStatus("CONNECTING");
+
+  const int MAX_RETRIES = 5;
+  for (int retry = 1; retry <= MAX_RETRIES; retry++) {
+    Serial.printf("\n🔄 Attempt %d of %d\n", retry, MAX_RETRIES);
+
+    if (tryConnectWiFiOnce(ssid, password)) {
+      Serial.printf("\n✅ WiFi connected! IP: %s\n", WiFi.localIP().toString().c_str());
+
+      // NVSに保存
+      saveWiFiCredentials(ssid, password);
+      wifiSSID = ssid;
+      wifiPassword = password;
+
+      // BLE MACをNVSに保存（以降の起動でdevice_idとして使用）
+      deviceMacAddress = BLEDevice::getAddress().toString().c_str();
+      saveDeviceMac(deviceMacAddress);
+
+      sendBLEStatus("CONNECTED");
+
+      // NVS保存済みなので再起動して通常モードへ（BLE deinitの詰まり回避）
+      delay(1000);
+      ESP.restart();
+      return;
+    }
+
+    Serial.printf("\n❌ Attempt %d failed\n", retry);
+
+    if (retry < MAX_RETRIES) {
+      Serial.println("⏳ Waiting 2 seconds before retry...");
+      delay(2000);
+    }
+  }
+
+  Serial.println("\n❌ WiFi connection failed after all retries");
+  sendBLEStatus("FAILED");
+}
+
+// ==== 通常動作開始（Soniox初期化〜STT録音） ====
+void startNormalOperation() {
+  Serial.println("🎯 Starting normal operation...");
+  currentMode = MODE_NORMAL;
+
+  // Soniox temp key取得
+  HTTPClient http;
+  http.begin(SONIOX_LAMBDA_URL);
+  int code = http.GET();
+  if (code != 200) {
+    Serial.printf("❌ HTTP fail %d\n", code);
+    setLEDMode(LED_OFF);
+    return;
+  }
+  String resp = http.getString();
+  http.end();
+
+  DynamicJsonDocument doc(512);
+  if (deserializeJson(doc, resp)) {
+    Serial.println("⚠️ JSON parse error");
+    setLEDMode(LED_OFF);
+    return;
+  }
+  sonioxKey = doc["api_key"].as<String>();
+  Serial.println("✅ Soniox temp key obtained");
+
+#if DEBUG_MEMORY
+  printMemoryStatus("After WiFi & Soniox Init");
+#endif
+
+  // STT録音開始（再生設定はsendToLambdaAndPlay()内で行う）
+  startSTTRecording();
+}
+
+// ==== SETUP ====
+void setup() {
+  Serial.begin(921600);
+  delay(100);
+  Serial.println("\n🚀 ToyTalk Conversation v2.0 (BLE WiFi Provisioning)");
+
+  // WiFiイベントハンドラ登録
+  WiFi.onEvent(WiFiEvent);
+
+  // LED初期化（PWM使用 - 新API）
+  ledcAttach(PIN_LED, LED_FREQ, LED_RESOLUTION);
+  setLEDMode(LED_ON);  // 起動中は点灯
+
+  // NVSからBLE MACアドレスを読み込み（WiFi設定時に保存済みの場合）
+  deviceMacAddress = loadDeviceMac();
+  if (deviceMacAddress.length() > 0) {
+    Serial.printf("📱 Device MAC (from NVS): %s\n", deviceMacAddress.c_str());
+  }
+
+  // ボタン初期化 + barge-in用割り込み登録
+  pinMode(PIN_BUTTON, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(PIN_BUTTON), onBargeInButton, FALLING);
+
+  pinMode(PIN_AMP_SD, OUTPUT);
+  digitalWrite(PIN_AMP_SD, LOW);
+
+  // NVSからWiFi設定読み込み
+  if (loadWiFiCredentials()) {
+    // 設定あり → 接続試行
+    Serial.printf("📶 Connecting to WiFi: %s\n", wifiSSID.c_str());
+
+    const int MAX_RETRIES = 5;
+    bool connected = false;
+
+    for (int retry = 1; retry <= MAX_RETRIES; retry++) {
+      Serial.printf("\n🔄 Attempt %d of %d\n", retry, MAX_RETRIES);
+
+      if (tryConnectWiFiOnce(wifiSSID, wifiPassword)) {
+        connected = true;
+        break;
+      }
+
+      Serial.printf("\n❌ Attempt %d failed\n", retry);
+
+      if (retry < MAX_RETRIES) {
+        Serial.println("⏳ Waiting 2 seconds before retry...");
+        delay(2000);
+      }
+    }
+
+    if (connected) {
+      Serial.printf("\n✅ WiFi connected! IP: %s\n", WiFi.localIP().toString().c_str());
+      // セッションID生成（電源ON単位）
+      sessionId = String(millis()) + "-" + String(random(100000, 999999));
+      Serial.printf("🆔 Session ID: %s\n", sessionId.c_str());
+      startNormalOperation();
+    } else {
+      Serial.println("\n❌ WiFi connection failed, entering BLE provisioning mode");
+      startBLE();
+    }
+  } else {
+    // 設定なし → BLEモード
+    Serial.println("⚠️ No WiFi config, entering BLE provisioning mode");
+    startBLE();
+  }
+}
+
+// ==== ボタン長押し処理 ====
+void handleButtonLongPress() {
+  bool pressed = (digitalRead(PIN_BUTTON) == LOW);
+
+  if (pressed && !buttonLongPressTriggered) {
+    if (buttonPressStart == 0) {
+      buttonPressStart = millis();
+    } else if (millis() - buttonPressStart >= LONG_PRESS_MS) {
+      // 長押し検出
+      buttonLongPressTriggered = true;
+      if (currentMode == MODE_NORMAL) {
+        Serial.println("🔘 Long press detected - Entering BLE mode");
+        // 録音停止
+        if (isRecording) {
+          ws.disconnect();
+          isRecording = false;
+        }
+        WiFi.disconnect(true);
+        startBLE();
+      }
+    }
+  } else if (!pressed) {
+    buttonPressStart = 0;
+    buttonLongPressTriggered = false;
+  }
+}
+
+// ==== LOOP ====
+void loop() {
+  // ===== BLEモード処理 =====
+  if (currentMode == MODE_BLE_PROV) {
+    updateLEDAnimation();
+    handleButtonLongPress();
+
+    // BLE接続状態変化処理
+    if (!bleDeviceConnected && oldBleDeviceConnected) {
+      delay(500);
+      if (pServer) {
+        pServer->startAdvertising();
+      }
+    }
+    oldBleDeviceConnected = bleDeviceConnected;
+
+    delay(10);
+    return;  // 会話処理はスキップ
+  }
+
+  // ===== 通常モード: 会話処理 =====
+  ws.loop();
+
+  // LED演出更新
+  updateLEDAnimation();
+
+  // ボタン長押しチェック
+  handleButtonLongPress();
+
+  // ボタンチェック（デバウンス処理付き）- 短押し用
+  int reading = digitalRead(PIN_BUTTON);
+
+  // 読み取り値が変化したらデバウンスタイマーをリセット
+  if (reading != lastButtonReading) {
+    lastDebounceTime = millis();
+  }
+
+  // デバウンス時間経過後、安定した状態を確定
+  if ((millis() - lastDebounceTime) > debounceDelay) {
+    // 状態が変化した場合のみ処理
+    if (reading != buttonState) {
+      buttonState = reading;
+
+      // HIGHからLOWへの遷移（ボタン押下）のみ検知
+      if (buttonState == LOW) {
+        Serial.println("🔘 Button pressed");
+        // ここに将来の拡張処理を追加
+      }
+    }
+  }
+
+  lastButtonReading = reading;
+
+  // 録音データをWebSocketに送信
+  if (isRecording && wifiGotIP && ws.isConnected()) {
+    static uint32_t lastSend = 0;
+    if (millis() - lastSend > 5) {
+      int32_t raw[512];
+      int16_t pcm[512];
+      size_t n = 0;
+      i2s_read(I2S_NUM_0, (void*)raw, sizeof(raw), &n, portMAX_DELAY);
+      int samples = n / sizeof(int32_t);
+      for (int i = 0; i < samples; i++) {
+        pcm[i] = (int16_t)(raw[i] >> 14);
+      }
+      ws.sendBIN((uint8_t*)pcm, samples * sizeof(int16_t));
+      lastSend = millis();
+    }
+  }
+
+  // Sonioxエンドポイント検出 → 即座に確定（優先）
+  if (endpointDetected && partialText.length() > 0) {
+    if (partialText != lastFinalText) {
+      Serial.println("\n✅ 確定文（エンドポイント検出）:");
+      Serial.println(partialText);
+      lastFinalText = partialText;
+      sendToLambdaAndPlay(partialText);
+    }
+    endpointDetected = false;
+    armed = false;
+    partialText = "";
+    sonioxFinalBuf = "";
+  }
+  // 無音検出 → 確定文出力（フォールバック）
+  else if (armed && partialText.length() > 0 && (millis() - lastPartialMs) >= END_SILENCE_MS) {
+    if (partialText != lastFinalText) {
+      Serial.println("\n✅ 確定文（無音検出）:");
+      Serial.println(partialText);
+      lastFinalText = partialText;
+      sendToLambdaAndPlay(partialText);
+    }
+    armed = false;
+    partialText = "";
+    sonioxFinalBuf = "";
+  }
+}

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -85,11 +85,11 @@ enum LEDMode {
   LED_BLINKING    // 点滅（再生中）
 };
 
-LEDMode currentLEDMode = LED_OFF;
-unsigned long lastLEDUpdate = 0;
-int breathingValue = 0;
-bool breathingUp = true;
-bool blinkState = false;
+volatile LEDMode currentLEDMode = LED_OFF;
+volatile int breathingValue = 0;
+volatile bool breathingUp = true;
+volatile bool blinkState = false;
+hw_timer_t* ledTimer = NULL;
 bool ampOn = false;  // アンプON状態管理（ソフトスタート用）
 volatile bool bargeInRequested = false;  // 再生中のbarge-in（ボタン割り込み）フラグ
 
@@ -437,19 +437,47 @@ void printMemoryStatus(const char* label) {
 }
 #endif
 
+// ==== LED タイマー割り込み（30ms周期）====
+void IRAM_ATTR onLEDTimer() {
+  LEDMode mode = currentLEDMode;
+  if (mode == LED_BREATHING) {
+    if (breathingUp) {
+      breathingValue += 5;
+      if (breathingValue >= 16) {
+        breathingValue = 16;
+        breathingUp = false;
+      }
+    } else {
+      breathingValue -= 5;
+      if (breathingValue <= 3) {
+        breathingValue = 3;
+        breathingUp = true;
+      }
+    }
+    ledcWrite(PIN_LED, breathingValue);
+  }
+  else if (mode == LED_BLINKING) {
+    static uint8_t blinkCounter = 0;
+    blinkCounter++;
+    if (blinkCounter >= 10) {  // 30ms * 10 = 300ms
+      blinkCounter = 0;
+      blinkState = !blinkState;
+      ledcWrite(PIN_LED, blinkState ? 16 : 0);
+    }
+  }
+}
+
 // ==== LED制御関数（単色LED）====
 void setLEDMode(LEDMode mode) {
   if (currentLEDMode == mode) return;
   currentLEDMode = mode;
-  lastLEDUpdate = millis();
   breathingValue = 0;
   breathingUp = true;
   blinkState = false;
 
-  // 即座に状態を反映
   switch (mode) {
     case LED_OFF:
-      ledcWrite(PIN_LED, 0);    // 0=OFF (GPIO LOW)
+      ledcWrite(PIN_LED, 0);
       break;
     case LED_ON:
       ledcWrite(PIN_LED, 16);
@@ -462,42 +490,6 @@ void setLEDMode(LEDMode mode) {
       blinkState = true;
       ledcWrite(PIN_LED, 16);
       break;
-  }
-}
-
-// loop()から呼ぶLED更新
-void updateLEDAnimation() {
-  unsigned long now = millis();
-
-  if (currentLEDMode == LED_BREATHING) {
-    // ふわふわ: 30ms毎に明るさ変更
-    if (now - lastLEDUpdate > 30) {
-      lastLEDUpdate = now;
-
-      if (breathingUp) {
-        breathingValue += 5;
-        if (breathingValue >= 16) {
-          breathingValue = 16;
-          breathingUp = false;
-        }
-      } else {
-        breathingValue -= 5;
-        if (breathingValue <= 3) {  // 完全に消さず、3で折り返し
-          breathingValue = 3;
-          breathingUp = true;
-        }
-      }
-
-      ledcWrite(PIN_LED, breathingValue);  // PWM値そのまま
-    }
-  }
-  else if (currentLEDMode == LED_BLINKING) {
-    // 点滅: 300ms毎にON/OFF
-    if (now - lastLEDUpdate > 300) {
-      lastLEDUpdate = now;
-      blinkState = !blinkState;
-      ledcWrite(PIN_LED, blinkState ? 16 : 0);
-    }
   }
 }
 
@@ -798,7 +790,7 @@ bool processPCM(WiFiClientSecure& client, uint32_t length) {
   uint32_t totalPlayed = 0;
 
   while (remaining > 0) {
-    updateLEDAnimation();
+
 
     // === Barge-in チェック（ISRでフラグが立っていれば即中断） ===
     if (bargeInRequested) {
@@ -1491,6 +1483,11 @@ void setup() {
   ledcAttach(PIN_LED, LED_FREQ, LED_RESOLUTION);
   setLEDMode(LED_ON);  // 起動中は点灯
 
+  // LEDアニメーション用ハードウェアタイマー（30ms周期）
+  ledTimer = timerBegin(1000000);  // 1MHz
+  timerAttachInterrupt(ledTimer, &onLEDTimer);
+  timerAlarm(ledTimer, 30000, true, 0);  // 30ms = 30000us, auto-reload
+
   // NVSからBLE MACアドレスを読み込み（WiFi設定時に保存済みの場合）
   deviceMacAddress = loadDeviceMac();
   if (deviceMacAddress.length() > 0) {
@@ -1576,7 +1573,7 @@ void handleButtonLongPress() {
 void loop() {
   // ===== BLEモード処理 =====
   if (currentMode == MODE_BLE_PROV) {
-    updateLEDAnimation();
+
     handleButtonLongPress();
 
     // BLE接続状態変化処理
@@ -1594,9 +1591,6 @@ void loop() {
 
   // ===== 通常モード: 会話処理 =====
   ws.loop();
-
-  // LED演出更新
-  updateLEDAnimation();
 
   // ボタン長押しチェック
   handleButtonLongPress();
@@ -1632,7 +1626,7 @@ void loop() {
       int32_t raw[512];
       int16_t pcm[512];
       size_t n = 0;
-      i2s_read(I2S_NUM_0, (void*)raw, sizeof(raw), &n, portMAX_DELAY);
+      i2s_read(I2S_NUM_0, (void*)raw, sizeof(raw), &n, pdMS_TO_TICKS(10));
       int samples = n / sizeof(int32_t);
       for (int i = 0; i < samples; i++) {
         pcm[i] = (int16_t)(raw[i] >> 14);

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -156,6 +156,22 @@ size_t backchannelPcmSize = 0;
 String backchannelText = "";
 TaskHandle_t backchannelTaskHandle = NULL;
 
+// 過去の相槌リスト（セッション内で重複回避）
+const int MAX_PAST_BACKCHANNELS = 10;
+String pastBackchannels[MAX_PAST_BACKCHANNELS];
+int pastBackchannelCount = 0;
+
+void addPastBackchannel(const String& text) {
+  if (pastBackchannelCount >= MAX_PAST_BACKCHANNELS) {
+    for (int i = 0; i < pastBackchannelCount - 1; i++) {
+      pastBackchannels[i] = pastBackchannels[i + 1];
+    }
+    pastBackchannelCount--;
+  }
+  pastBackchannels[pastBackchannelCount] = text;
+  pastBackchannelCount++;
+}
+
 // ==== セッションID（電源ON/OFF単位） ====
 String sessionId = "";
 
@@ -877,6 +893,25 @@ void fetchBackchannelTask(void* param) {
   if (charId.length() > 0 && charId != "default") {
     payload += ",\"character_id\":\"" + charId + "\"";
   }
+  // 会話履歴（直近6ターン）
+  if (historyCount > 0) {
+    payload += ",\"history\":[";
+    int start = (historyCount > 6) ? historyCount - 6 : 0;
+    for (int i = start; i < historyCount; i++) {
+      if (i > start) payload += ",";
+      payload += "{\"role\":\"" + conversationHistory[i].role + "\",\"content\":\"" + conversationHistory[i].content + "\"}";
+    }
+    payload += "]";
+  }
+  // 過去の相槌（重複回避用）
+  if (pastBackchannelCount > 0) {
+    payload += ",\"past_backchannels\":[";
+    for (int i = 0; i < pastBackchannelCount; i++) {
+      if (i > 0) payload += ",";
+      payload += "\"" + pastBackchannels[i] + "\"";
+    }
+    payload += "]";
+  }
   payload += "}";
 
   // ブロックスコープでHTTPClientのデストラクタを確実に呼ぶ
@@ -1040,6 +1075,9 @@ bool playBackchannelIfReady() {
   }
 
   backchannelFired = true;
+  if (backchannelText.length() > 0) {
+    addPastBackchannel(backchannelText);
+  }
   Serial.println("[BC] Backchannel playback done");
 
   // PCM解放

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -1017,20 +1017,6 @@ bool playBackchannelIfReady() {
 
   Serial.printf("[BC] Playing backchannel: %d bytes\n", backchannelPcmSize);
 
-  // アンプON（ソフトスタート）
-  if (!ampOn) {
-    ledcAttach(PIN_AMP_SD, 1000, 8);
-    for (int i = 0; i <= 255; i += 5) {
-      ledcWrite(PIN_AMP_SD, i);
-      delay(2);
-    }
-    ledcDetach(PIN_AMP_SD);
-    pinMode(PIN_AMP_SD, OUTPUT);
-    digitalWrite(PIN_AMP_SD, HIGH);
-    delay(50);
-    ampOn = true;
-  }
-
   // mono→stereo変換して再生
   size_t samples = backchannelPcmSize / 2;
   const size_t PLAY_CHUNK = 4096;
@@ -1124,6 +1110,21 @@ void sendToLambdaAndPlay(const String& text) {
   TaskHandle_t connTaskHandle = NULL;
   xTaskCreatePinnedToCore(lambdaConnectTask, "lambda_conn", 16384, &connParams, 1, &connTaskHandle, 0);
   Serial.printf("⏱️ [%lums] Lambda connect task started on Core 0\n", millis() - t0);
+
+  // アンプON（ソフトスタート）— Lambda SSL接続と並列で実行
+  if (!ampOn) {
+    ledcAttach(PIN_AMP_SD, 1000, 8);
+    for (int i = 0; i <= 255; i += 5) {
+      ledcWrite(PIN_AMP_SD, i);
+      delay(2);
+    }
+    ledcDetach(PIN_AMP_SD);
+    pinMode(PIN_AMP_SD, OUTPUT);
+    digitalWrite(PIN_AMP_SD, HIGH);
+    delay(50);
+    ampOn = true;
+    Serial.printf("⏱️ [%lums] Amp ready\n", millis() - t0);
+  }
 
   // ② 相槌を即座に再生（Lambda接続と並列）
   if (backchannelReady && backchannelPcm && backchannelPcmSize > 0) {

--- a/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_mini_v0.2/toytalker_mini_v0.2.ino
@@ -1006,7 +1006,7 @@ void startBackchannelFetch(const String& partial) {
     params,
     1,          // 低優先度
     &backchannelTaskHandle,
-    0           // Core 0（メインループはCore 1）
+    1           // Core 1（Core 0のWiFiスタックと競合しない）
   );
 }
 
@@ -1050,18 +1050,26 @@ bool playBackchannelIfReady() {
   return true;
 }
 
-// ---- Lambda SSL接続バックグラウンドタスク ----
+// ---- Lambda SSL接続+リクエスト送信バックグラウンドタスク ----
 struct LambdaConnectParams {
   WiFiClientSecure* client;
-  volatile bool done;
-  volatile bool ok;
+  String* request;
+  volatile bool connected;
+  volatile bool sent;
+  volatile bool failed;
 };
 
-void lambdaConnectTask(void* param) {
+void lambdaConnectAndSendTask(void* param) {
   LambdaConnectParams* p = (LambdaConnectParams*)param;
   p->client->setInsecure();
-  p->ok = p->client->connect(LAMBDA_HOST, 443);
-  p->done = true;
+  if (!p->client->connect(LAMBDA_HOST, 443)) {
+    p->failed = true;
+    vTaskDelete(NULL);
+    return;
+  }
+  p->connected = true;
+  p->client->print(*(p->request));
+  p->sent = true;
   vTaskDelete(NULL);
 }
 
@@ -1104,53 +1112,7 @@ void sendToLambdaAndPlay(const String& text) {
   ws.disconnect();
   Serial.printf("⏱️ [%lums] WS disconnected\n", millis() - t0);
 
-  // ① Lambda SSL接続をCore 0でバックグラウンド開始
-  WiFiClientSecure client;
-  LambdaConnectParams connParams = { &client, false, false };
-  TaskHandle_t connTaskHandle = NULL;
-  xTaskCreatePinnedToCore(lambdaConnectTask, "lambda_conn", 16384, &connParams, 1, &connTaskHandle, 0);
-  Serial.printf("⏱️ [%lums] Lambda connect task started on Core 0\n", millis() - t0);
-
-  // アンプON（ソフトスタート）— Lambda SSL接続と並列で実行
-  if (!ampOn) {
-    ledcAttach(PIN_AMP_SD, 1000, 8);
-    for (int i = 0; i <= 255; i += 5) {
-      ledcWrite(PIN_AMP_SD, i);
-      delay(2);
-    }
-    ledcDetach(PIN_AMP_SD);
-    pinMode(PIN_AMP_SD, OUTPUT);
-    digitalWrite(PIN_AMP_SD, HIGH);
-    delay(50);
-    ampOn = true;
-    Serial.printf("⏱️ [%lums] Amp ready\n", millis() - t0);
-  }
-
-  // ② 相槌を即座に再生（Lambda接続と並列）
-  if (backchannelReady && backchannelPcm && backchannelPcmSize > 0) {
-    Serial.println("[BC] Playing backchannel while Lambda connects...");
-    playBackchannelIfReady();
-  }
-  Serial.printf("⏱️ [%lums] Backchannel phase done\n", millis() - t0);
-
-  // ③ Lambda接続完了を待つ
-  while (!connParams.done) {
-    delay(1);
-  }
-  Serial.printf("⏱️ [%lums] Lambda connected (ok=%d)\n", millis() - t0, connParams.ok);
-
-  if (!connParams.ok) {
-    Serial.printf("💾 Free heap at failure: %d\n", ESP.getFreeHeap());
-    setLEDMode(LED_OFF);
-    i2s_stop(I2S_NUM_1);
-    i2s_driver_uninstall(I2S_NUM_1);
-    if (ampOn) { digitalWrite(PIN_AMP_SD, LOW); ampOn = false; }
-    clearBackchannelCache();
-    startSTTRecording();
-    return;
-  }
-
-  // ④ リクエスト送信
+  // ① ペイロードを先に組み立て
   String messagesJson = "[";
   for (int i = 0; i < historyCount; i++) {
     if (i > 0) messagesJson += ",";
@@ -1180,8 +1142,51 @@ void sendToLambdaAndPlay(const String& text) {
     "Content-Length: " + payload.length() + "\r\n\r\n"
     + payload;
 
-  client.print(req);
-  Serial.printf("⏱️ [%lums] Request sent\n", millis() - t0);
+  // ② Lambda SSL接続+リクエスト送信をCore 0でバックグラウンド開始
+  WiFiClientSecure client;
+  LambdaConnectParams connParams = { &client, &req, false, false, false };
+  TaskHandle_t connTaskHandle = NULL;
+  xTaskCreatePinnedToCore(lambdaConnectAndSendTask, "lambda_conn", 16384, &connParams, 1, &connTaskHandle, 0);
+  Serial.printf("⏱️ [%lums] Lambda task started on Core 0\n", millis() - t0);
+
+  // ③ アンプON（ソフトスタート）— Lambda接続と並列で実行
+  if (!ampOn) {
+    ledcAttach(PIN_AMP_SD, 1000, 8);
+    for (int i = 0; i <= 255; i += 5) {
+      ledcWrite(PIN_AMP_SD, i);
+      delay(2);
+    }
+    ledcDetach(PIN_AMP_SD);
+    pinMode(PIN_AMP_SD, OUTPUT);
+    digitalWrite(PIN_AMP_SD, HIGH);
+    delay(50);
+    ampOn = true;
+    Serial.printf("⏱️ [%lums] Amp ready\n", millis() - t0);
+  }
+
+  // ④ 相槌を即座に再生（Lambda接続+送信と並列）
+  if (backchannelReady && backchannelPcm && backchannelPcmSize > 0) {
+    Serial.println("[BC] Playing backchannel while Lambda connects...");
+    playBackchannelIfReady();
+  }
+  Serial.printf("⏱️ [%lums] Backchannel phase done\n", millis() - t0);
+
+  // ⑤ Lambda接続+送信完了を待つ
+  while (!connParams.sent && !connParams.failed) {
+    delay(1);
+  }
+  Serial.printf("⏱️ [%lums] Lambda request sent (ok=%d)\n", millis() - t0, !connParams.failed);
+
+  if (connParams.failed) {
+    Serial.printf("💾 Free heap at failure: %d\n", ESP.getFreeHeap());
+    setLEDMode(LED_OFF);
+    i2s_stop(I2S_NUM_1);
+    i2s_driver_uninstall(I2S_NUM_1);
+    if (ampOn) { digitalWrite(PIN_AMP_SD, LOW); ampOn = false; }
+    clearBackchannelCache();
+    startSTTRecording();
+    return;
+  }
 
   // ③ HTTPレスポンスヘッダー読み取り
   while (true) {

--- a/devices/mcu/esp32_s3/toytalker_v0.2/toytalker_v0.2.ino
+++ b/devices/mcu/esp32_s3/toytalker_v0.2/toytalker_v0.2.ino
@@ -1309,6 +1309,8 @@ void loop() {
   // 録音データをWebSocketに送信
   if (isRecording && wifiGotIP && ws.isConnected()) {
     static uint32_t lastSend = 0;
+    static uint32_t sendOk = 0, sendFail = 0;
+    static uint32_t lastStats = 0;
     if (millis() - lastSend > 5) {
       int32_t raw[512];
       int16_t pcm[512];
@@ -1318,8 +1320,14 @@ void loop() {
       for (int i = 0; i < samples; i++) {
         pcm[i] = (int16_t)(raw[i] >> 14);
       }
-      ws.sendBIN((uint8_t*)pcm, samples * sizeof(int16_t));
+      bool ok = ws.sendBIN((uint8_t*)pcm, samples * sizeof(int16_t));
+      if (ok) sendOk++; else sendFail++;
       lastSend = millis();
+    }
+    if (millis() - lastStats > 5000) {
+      Serial.printf("[STT] send ok=%d fail=%d RSSI=%d\n", sendOk, sendFail, WiFi.RSSI());
+      sendOk = 0; sendFail = 0;
+      lastStats = millis();
     }
   }
 


### PR DESCRIPTION
## Summary
- ESP32向け相槌（バックチャネル）機能を追加。録音中にバックグラウンドでLLM+TTS生成し、自然な会話フローを実現
- LED安定化のためハードウェアタイマー割り込みに移行
- Lambda SSL接続・アンプ起動・相槌再生の並列化で応答レイテンシを大幅短縮
- DMAバッファ削減（32→8）で再生後の無音時間を1.36s→340msに短縮
- デバイスごとの相槌ON/OFF設定（DynamoDB連携）
- Soniox STTモデルバージョンをLambda環境変数で一元管理
- Gemini LLMのthinking text漏れ修正
- デバイスID→キャラクター→ボイス解決チェーンでESP相槌ボイスを正しくマッチング

## Test plan
- [x] 相槌が録音中に自然なタイミングで再生されること
- [x] アプリからデバイスごとに相槌ON/OFFできること
- [x] OFF時にbackchannel Lambdaへのリクエストが飛ばないこと
- [x] Gemini使用時にthinking textが音声再生されないこと
- [x] デバイスに割り当てたキャラクターの声で相槌が再生されること
- [x] STTモデルバージョンがLambda環境変数から反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)