### PR TITLE
Preconnect Soniox WebSocket for instant STT restart

### DIFF
--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -478,6 +478,7 @@ export default function Chat() {
   };
 
   const startSonioxSTT = async () => {
+    const sttT0 = Date.now();
     if(DEBUG)setLog(L => [...L, "Soniox STT: start()"]);
 
     // すでに起動中なら無視（多重起動防止）
@@ -489,6 +490,7 @@ export default function Chat() {
     // 権限チェック
     const okAndroid = await ensureMicPermissionAndroid();
     const okIOS = await ensureMicPermissionIOS();
+    console.log(`⏱️ STT [${Date.now() - sttT0}ms] mic permission checked`);
     if (!okAndroid || !okIOS) {
       setLog(L => [...L, "STT: マイク権限がありません"]);
       return;
@@ -505,6 +507,7 @@ export default function Chat() {
     let gotServerMsg = false;
 
     // 新規WS
+    console.log(`⏱️ STT [${Date.now() - sttT0}ms] creating WebSocket`);
     const ws = new WebSocket(SONIOX_WS_URL);
     ws.binaryType = "arraybuffer";
     sonioxWsRef.current = ws;
@@ -519,7 +522,7 @@ export default function Chat() {
 
     ws.onopen = async () => {
       if (!guard()) return;
-
+      console.log(`⏱️ STT [${Date.now() - sttT0}ms] WebSocket OPEN`);
 
       // サーバへ設定送信（まず設定→次に音声）
       const cfg = {
@@ -535,6 +538,7 @@ export default function Chat() {
       if(DEBUG)setLog(L => [...L, "Soniox WS: OPEN + cfg sent"]);
 
       // 録音開始（onopen後に開始）
+      console.log(`⏱️ STT [${Date.now() - sttT0}ms] configuring AudioRecord`);
       configureAudioRecord();
       AudioRecord.on("data", (b64: string) => {
         if (!guard()) return;                   // 古いセッションは無視
@@ -551,7 +555,9 @@ export default function Chat() {
       });
 
       try {
+        console.log(`⏱️ STT [${Date.now() - sttT0}ms] AudioRecord.start()`);
         await AudioRecord.start();
+        console.log(`⏱️ STT [${Date.now() - sttT0}ms] AudioRecord started OK`);
         sonioxListeningRef.current = true;
         setIsListening(true);
         setPartial(""); setFinalText("");
@@ -846,6 +852,7 @@ export default function Chat() {
         console.log("🔄 playLoop restarting (Sound)");
         playLoop();
       } else {
+        const t0 = Date.now();
         console.log("🎙️ Auto restart STT after playback");
 
         const doAutoRestart = async () => {
@@ -859,8 +866,10 @@ export default function Chat() {
             return;
           }
 
+          console.log(`⏱️ [${Date.now() - t0}ms] before startSonioxSTT`);
           if (sttMode === "soniox") {
-            startSonioxSTT();
+            await startSonioxSTT();
+            console.log(`⏱️ [${Date.now() - t0}ms] startSonioxSTT returned`);
           } else if (sttMode === "local") {
             console.log("🎤 preparing local STT restart");
             try {

--- a/app/app/(tabs)/chat.tsx
+++ b/app/app/(tabs)/chat.tsx
@@ -447,6 +447,7 @@ export default function Chat() {
   /* === Soniox: リアルタイムWS === */
   const sonioxWsRef = useRef<WebSocket | null>(null);
   const sonioxListeningRef = useRef(false);
+  const preconnectedWsRef = useRef<WebSocket | null>(null);
   const sonioxFinalBufRef = useRef<string>(""); // final確定の蓄積
   const sonioxNonFinalBufRef = useRef<string>(""); // 非確定の表示用
 
@@ -475,6 +476,40 @@ export default function Chat() {
     if (!res.ok || !js?.api_key) throw new Error("Failed to get Soniox temp key");
     if (js.stt_model) SONIOX_MODEL = js.stt_model;
     return js.api_key as string;
+  };
+
+  // Soniox WS先行接続（再生中に呼ぶ）
+  const preconnectSonioxWs = async () => {
+    if (preconnectedWsRef.current) return;
+    console.log("⏱️ preconnect: creating WebSocket");
+    const ws = new WebSocket(SONIOX_WS_URL);
+    ws.binaryType = "arraybuffer";
+    preconnectedWsRef.current = ws;
+
+    ws.onopen = async () => {
+      console.log("⏱️ preconnect: WebSocket OPEN, sending config");
+      const cfg = {
+        api_key: sonioxKey ?? (await fetchSonioxTempKey()),
+        model: SONIOX_MODEL,
+        audio_format: "pcm_s16le",
+        sample_rate: SONIOX_SAMPLE_RATE,
+        num_channels: SONIOX_CHANNELS,
+        enable_endpoint_detection: true,
+        language_hints: ["ja","en"],
+      };
+      ws.send(JSON.stringify(cfg));
+    };
+
+    ws.onerror = () => {
+      console.log("⏱️ preconnect: WebSocket error");
+      preconnectedWsRef.current = null;
+    };
+
+    ws.onclose = () => {
+      if (preconnectedWsRef.current === ws) {
+        preconnectedWsRef.current = null;
+      }
+    };
   };
 
   const startSonioxSTT = async () => {
@@ -506,9 +541,18 @@ export default function Chat() {
     let bytesSent = 0;
     let gotServerMsg = false;
 
-    // 新規WS
-    console.log(`⏱️ STT [${Date.now() - sttT0}ms] creating WebSocket`);
-    const ws = new WebSocket(SONIOX_WS_URL);
+    // 先行接続済みWSがあれば再利用
+    const preWs = preconnectedWsRef.current;
+    const usePreconnected = preWs && preWs.readyState === WebSocket.OPEN;
+    if (usePreconnected) {
+      console.log(`⏱️ STT [${Date.now() - sttT0}ms] using preconnected WebSocket`);
+    } else {
+      console.log(`⏱️ STT [${Date.now() - sttT0}ms] creating new WebSocket`);
+      if (preWs) try { preWs.close(); } catch {}
+    }
+    preconnectedWsRef.current = null;
+
+    const ws = usePreconnected ? preWs! : new WebSocket(SONIOX_WS_URL);
     ws.binaryType = "arraybuffer";
     sonioxWsRef.current = ws;
 
@@ -520,28 +564,12 @@ export default function Chat() {
       sonioxWatchRef.current = null;
     };
 
-    ws.onopen = async () => {
-      if (!guard()) return;
-      console.log(`⏱️ STT [${Date.now() - sttT0}ms] WebSocket OPEN`);
-
-      // サーバへ設定送信（まず設定→次に音声）
-      const cfg = {
-        api_key: sonioxKey ?? (await fetchSonioxTempKey()),
-        model: SONIOX_MODEL,
-        audio_format: "pcm_s16le",
-        sample_rate: SONIOX_SAMPLE_RATE,
-        num_channels: SONIOX_CHANNELS,
-        enable_endpoint_detection: true,
-        language_hints: ["ja","en"],
-      };
-      ws.send(JSON.stringify(cfg));
-      if(DEBUG)setLog(L => [...L, "Soniox WS: OPEN + cfg sent"]);
-
-      // 録音開始（onopen後に開始）
+    // 録音開始処理（WS接続済み後に呼ぶ）
+    const beginRecording = async () => {
       console.log(`⏱️ STT [${Date.now() - sttT0}ms] configuring AudioRecord`);
       configureAudioRecord();
       AudioRecord.on("data", (b64: string) => {
-        if (!guard()) return;                   // 古いセッションは無視
+        if (!guard()) return;
         if (!sonioxListeningRef.current) return;
 
         try {
@@ -568,13 +596,36 @@ export default function Chat() {
       } catch (e: any) {
         setIsListening(false);
         setLog(L => [...L, `AudioRecord.start failed: ${e?.message ?? e}`]);
-        // 録音開始に失敗したら即終了
         try { ws.close(); } catch {}
         sonioxListeningRef.current = false;
         setIsListening(false);
         return;
       }
     };
+
+    if (usePreconnected) {
+      // 先行接続済み: config送信済み、即録音開始
+      await beginRecording();
+    } else {
+      ws.onopen = async () => {
+        if (!guard()) return;
+        console.log(`⏱️ STT [${Date.now() - sttT0}ms] WebSocket OPEN`);
+
+        const cfg = {
+          api_key: sonioxKey ?? (await fetchSonioxTempKey()),
+          model: SONIOX_MODEL,
+          audio_format: "pcm_s16le",
+          sample_rate: SONIOX_SAMPLE_RATE,
+          num_channels: SONIOX_CHANNELS,
+          enable_endpoint_detection: true,
+          language_hints: ["ja","en"],
+        };
+        ws.send(JSON.stringify(cfg));
+        if(DEBUG)setLog(L => [...L, "Soniox WS: OPEN + cfg sent"]);
+
+        await beginRecording();
+      };
+    }
 
     ws.onmessage = (ev) => {
       if (!guard()) return;
@@ -831,6 +882,10 @@ export default function Chat() {
             console.log("✅ Sound loaded:", path);
             currentSoundRef.current = s;
             loopBeatRef.current = Date.now();
+            // 最後のチャンクならSoniox WSを先行接続
+            if (queueRef.current.length === 0 && sttMode === "soniox") {
+              preconnectSonioxWs();
+            }
             s.play((success) => {
               if (success) console.log("🏁 Finished playing:", path);
               else console.log("⚠️ Playback failed:", path);


### PR DESCRIPTION
## Summary
- 再生の最後のチャンクが始まった時点でSoniox WebSocketを事前接続し、再生終了→録音開始の遷移を高速化
- STT再開時間が ~2000ms → ~110ms に短縮
- 計測用タイミングログも追加

## Test plan
- [x] 再生終了後すぐに録音モードに移行することを確認済み
- [x] preconnected WebSocket が正しく再利用されることをログで確認済み
- [ ] 通常のSTT開始（preconnectなし）も引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)