### PR TITLE
Add ZakiCorp clone voice TTS with custom voice management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,38 @@
 
 - 「コミットして」と言われたらコミットだけ行う。PR作成・マージ・ブランチクリーンアップは明示的な指示があるまでやらない。
 - Lambda関数を修正したら、コミット前にデプロイする。各Lambda配下の `deploy.sh` を実行（例: `cd backend/<lambda-dir> && bash deploy.sh`）。
+
+## ZakiCorp TTS（クローンボイス, β版）
+
+ローカルPC (RTX 5090) でQwen3-TTSベースのクローンボイスAPIサーバーを稼働。ngrokでインターネットに公開し、Lambdaから利用する。
+
+### 起動手順（PC再起動後など）
+
+1. **APIサーバー起動** — ターミナルで:
+   ```
+   cd C:\Users\exodj\projects\tts-models\faster-qwen3-tts
+   set ZAKICORP_API_KEY=<メモリ参照>
+   python api_server.py
+   ```
+   ポート8000、モデルウォームアップ約8-9秒、speaker_*.ptを自動ロード
+
+2. **ngrokトンネル起動** — 別ターミナルで:
+   ```
+   ngrok http 8000
+   ```
+   無料プランのためURLは再起動で変わる
+
+### ngrok URL変更時のLambda環境変数更新対象
+
+`ZAKICORP_TTS_URL` を新しいngrok URLに更新する:
+
+1. `toytalk-stream-handler-lambda` (app TTS)
+2. `toytalk-api-stream-for-esp32-lambda` (ESP32 TTS)
+3. `toytalker-backchannel-for-app-lambda` (app 相槌)
+4. `toytalker-backchannel-for-esp32-lambda` (ESP32 相槌)
+5. `toytalker-device-setting-lambda` (ボイス登録) ※追加予定
+
+### S3 / DynamoDB
+
+- S3バケット: `toytalker-tts-speakers` — speaker embedding (.pt) のバックアップ保管
+- DynamoDBテーブル: `toytalker-voices` — ZakiCorpボイスエントリ (provider=ZakiCorp, voice_id=zakicorp-{name}, vendor_id={name})

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 
 - 「コミットして」と言われたらコミットだけ行う。PR作成・マージ・ブランチクリーンアップは明示的な指示があるまでやらない。
 - Lambda関数を修正したら、コミット前にデプロイする。各Lambda配下の `deploy.sh` を実行（例: `cd backend/<lambda-dir> && bash deploy.sh`）。
+- PowerShellでgitコマンドを実行するとき、`Set-Location` を使わず `git` から直接実行する（パーミッション設定のパターンマッチが効かなくなるため）。
 
 ## ZakiCorp TTS（クローンボイス, β版）
 

--- a/app/app.json
+++ b/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "ToyTalk",
     "slug": "toytalk",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "toytalk",
@@ -10,7 +10,7 @@
     "newArchEnabled": true,
     "ios": {
       "bundleIdentifier": "com.zakicorp.toytalk",
-      "buildNumber": "18",
+      "buildNumber": "19",
       "supportsTablet": false,
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -278,6 +278,8 @@ export default function Settings() {
   const [cvRegistering, setCvRegistering] = useState(false);
   const cvTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const cvWavPathRef = useRef<string>("");
+  const [editingVoiceId, setEditingVoiceId] = useState<string | null>(null);
+  const [editingVoiceLabel, setEditingVoiceLabel] = useState("");
   const CV_DURATION = 5;
   const CV_GUIDE_TEXT = "以下の文章を、普段の声で読み上げてください：\n\n「こんにちは！今日はとてもいい天気ですね。一緒にお散歩に行きませんか？楽しいお話をたくさんしましょう。」";
 
@@ -495,12 +497,15 @@ export default function Settings() {
               <Text style={{ fontSize: 15, color: "#555", lineHeight: 24 }}>{CV_GUIDE_TEXT}</Text>
             </View>
 
-            <TextInput
-              style={[s.input, { width: "100%", marginBottom: 20, textAlign: "center", fontSize: 18 }]}
-              placeholder="ボイスの名前（例: パパ、ママ）"
-              value={cvName}
-              onChangeText={setCvName}
-            />
+            <View style={{ flexDirection: "row", alignItems: "center", width: "100%", marginBottom: 20, gap: 10 }}>
+              <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>ボイス名</Text>
+              <TextInput
+                style={[s.input, { flex: 1, marginBottom: 0, fontSize: 18 }]}
+                placeholder="例: パパ、ママ"
+                value={cvName}
+                onChangeText={setCvName}
+              />
+            </View>
 
             {/* プログレスバー */}
             <View style={{ width: "100%", height: 8, backgroundColor: "#e0e0e0", borderRadius: 4, marginBottom: 8 }}>
@@ -549,27 +554,22 @@ export default function Settings() {
 
   // ---- カスタムボイス一覧画面 ----
   if (screen === "custom-voice-list") {
-    const systemVoices = customVoices.filter(v => v.owner_id === "system");
     const userVoices = customVoices.filter(v => v.owner_id !== "system");
 
-    const [editingVoiceId, setEditingVoiceId] = useState<string | null>(null);
-    const [editingVoiceLabel, setEditingVoiceLabel] = useState("");
-
-    const startRename = (voiceId: string, currentLabel: string) => {
-      setEditingVoiceId(voiceId);
-      setEditingVoiceLabel(currentLabel);
-    };
-
-    const submitRename = async () => {
-      if (!editingVoiceId || !editingVoiceLabel.trim()) return;
+    const saveVoiceLabel = async (voiceId: string, newLabel: string) => {
+      const original = customVoices.find(v => v.voice_id === voiceId)?.label;
+      if (!newLabel.trim() || newLabel.trim() === original) {
+        setEditingVoiceId(null);
+        return;
+      }
       try {
-        const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices/${encodeURIComponent(editingVoiceId)}`, {
+        const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices/${encodeURIComponent(voiceId)}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ label: editingVoiceLabel.trim() }),
+          body: JSON.stringify({ label: newLabel.trim() }),
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        setCustomVoices(prev => prev.map(v => v.voice_id === editingVoiceId ? { ...v, label: editingVoiceLabel.trim() } : v));
+        setCustomVoices(prev => prev.map(v => v.voice_id === voiceId ? { ...v, label: newLabel.trim() } : v));
       } catch {
         Alert.alert("エラー", "名前の変更に失敗しました");
       }
@@ -578,37 +578,30 @@ export default function Settings() {
 
     const renderVoiceRow = (v: CustomVoiceItem, editable: boolean) => (
       <View key={v.voice_id} style={[s.navRow, { flexDirection: "column", alignItems: "flex-start", gap: 4 }]}>
-        {editingVoiceId === v.voice_id ? (
-          <View style={{ flexDirection: "row", width: "100%", alignItems: "center", gap: 8 }}>
+        <View style={{ flexDirection: "row", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
+          {editingVoiceId === v.voice_id ? (
             <TextInput
               style={[s.input, { flex: 1, marginBottom: 0 }]}
               value={editingVoiceLabel}
               onChangeText={setEditingVoiceLabel}
               autoFocus
-              onSubmitEditing={submitRename}
+              onBlur={() => saveVoiceLabel(v.voice_id, editingVoiceLabel)}
+              onSubmitEditing={() => saveVoiceLabel(v.voice_id, editingVoiceLabel)}
             />
-            <TouchableOpacity onPress={submitRename}>
-              <Text style={{ color: "#007AFF", fontSize: 14, fontWeight: "600" }}>保存</Text>
+          ) : (
+            <TouchableOpacity
+              style={{ flex: 1 }}
+              onPress={() => { if (editable) { setEditingVoiceId(v.voice_id); setEditingVoiceLabel(v.label); } }}
+            >
+              <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>{v.label}</Text>
             </TouchableOpacity>
-            <TouchableOpacity onPress={() => setEditingVoiceId(null)}>
-              <Text style={{ color: "#999", fontSize: 14 }}>取消</Text>
+          )}
+          {editable && editingVoiceId !== v.voice_id && (
+            <TouchableOpacity onPress={() => deleteCustomVoice(v.voice_id)}>
+              <Text style={{ color: "#FF3B30", fontSize: 14 }}>削除</Text>
             </TouchableOpacity>
-          </View>
-        ) : (
-          <View style={{ flexDirection: "row", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
-            <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>{v.label}</Text>
-            {editable && (
-              <View style={{ flexDirection: "row", gap: 16 }}>
-                <TouchableOpacity onPress={() => startRename(v.voice_id, v.label)}>
-                  <Text style={{ color: "#007AFF", fontSize: 14 }}>編集</Text>
-                </TouchableOpacity>
-                <TouchableOpacity onPress={() => deleteCustomVoice(v.voice_id)}>
-                  <Text style={{ color: "#FF3B30", fontSize: 14 }}>削除</Text>
-                </TouchableOpacity>
-              </View>
-            )}
-          </View>
-        )}
+          )}
+        </View>
       </View>
     );
 
@@ -621,24 +614,13 @@ export default function Settings() {
             </TouchableOpacity>
             <Text style={s.headerTitle}>カスタムボイス</Text>
           </View>
-          <ScrollView contentContainerStyle={s.wrap}>
+          <ScrollView contentContainerStyle={s.wrap} keyboardShouldPersistTaps="handled">
             {customVoicesLoading ? (
               <ActivityIndicator style={{ marginTop: 32 }} />
+            ) : userVoices.length === 0 ? (
+              <Text style={{ textAlign: "center", color: "#999", marginTop: 32, fontSize: 15 }}>まだカスタムボイスがありません</Text>
             ) : (
-              <>
-                {systemVoices.length > 0 && (
-                  <>
-                    <Text style={{ fontSize: 13, fontWeight: "600", color: "#999", marginTop: 16, marginBottom: 8 }}>ZakiCorp（システム）</Text>
-                    {systemVoices.map(v => renderVoiceRow(v, false))}
-                  </>
-                )}
-                <Text style={{ fontSize: 13, fontWeight: "600", color: "#999", marginTop: 20, marginBottom: 8 }}>ZakiCorp（カスタム）</Text>
-                {userVoices.length === 0 ? (
-                  <Text style={{ textAlign: "center", color: "#bbb", marginTop: 12, fontSize: 14 }}>まだカスタムボイスがありません</Text>
-                ) : (
-                  userVoices.map(v => renderVoiceRow(v, true))
-                )}
-              </>
+              userVoices.map(v => renderVoiceRow(v, true))
             )}
 
             <TouchableOpacity style={[s.button, { marginTop: 24 }]} onPress={openCustomVoiceRecord}>
@@ -1001,13 +983,33 @@ export default function Settings() {
   }
 
   const providerOrder = [...new Set(voices.map((v) => v.provider))];
-  const voiceSections = providerOrder
-    .map((provider) => ({ title: provider, data: voices.filter((v) => v.provider === provider) }))
-    .filter((sec) => sec.data.length > 0);
+  const voiceSections: { title: string; data: VoiceItem[] }[] = [];
+  const zakicorpSystem: VoiceItem[] = [];
+  for (const provider of providerOrder) {
+    const providerVoices = voices.filter((v) => v.provider === provider);
+    if (providerVoices.length === 0) continue;
+    if (provider === "ZakiCorp") {
+      zakicorpSystem.push(...providerVoices);
+    } else {
+      voiceSections.push({ title: provider, data: providerVoices });
+    }
+  }
+  if (zakicorpSystem.length > 0) {
+    voiceSections.push({ title: "ZakiCorp（システム）", data: zakicorpSystem });
+  }
+  const customAsVoice = customVoices
+    .filter(v => v.owner_id !== "system")
+    .map(v => ({ voice_id: v.voice_id, label: v.label, provider: "ZakiCorp", vendor_id: v.vendor_id }));
+  if (customAsVoice.length > 0) {
+    voiceSections.push({ title: "ZakiCorp（カスタム）", data: customAsVoice });
+  }
 
   const currentVoiceLabel = () => {
     const v = voices.find((v) => v.voice_id === charVoiceId);
-    return v ? `${v.label} (${v.provider})` : charVoiceId;
+    if (v) return `${v.label} (${v.provider})`;
+    const cv = customVoices.find((v) => v.voice_id === charVoiceId);
+    if (cv) return `${cv.label} (ZakiCorp)`;
+    return charVoiceId;
   };
 
   const currentLlmLabel = () => {
@@ -1137,7 +1139,7 @@ export default function Settings() {
           />
 
           <Text style={[s.sectionTitle, { marginTop: 16 }]}>ボイス</Text>
-          <TouchableOpacity style={s.settingRow} onPress={() => navigateTo("voice-select")}>
+          <TouchableOpacity style={s.settingRow} onPress={() => { loadCustomVoices(); navigateTo("voice-select"); }}>
             <Text style={s.settingRowText}>{voicesLoading ? "読み込み中..." : currentVoiceLabel()}</Text>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -17,10 +17,13 @@ import {
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useRef, useState } from "react";
 import { useOwnerId } from "../../hooks/useOwnerId";
+import AudioRecord from "react-native-audio-record";
+import { Audio } from "expo-av";
+import * as FileSystem from "expo-file-system";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
-type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "llm-select" | "version" | "usage" | "usage-detail";
+type SettingsScreen = "main" | "stt-select" | "character-list" | "character-edit" | "voice-select" | "llm-select" | "version" | "usage" | "usage-detail" | "custom-voice-list" | "custom-voice-record";
 
 type CharacterItem = {
   character_id: string;
@@ -265,6 +268,135 @@ export default function Settings() {
     }
   };
 
+  // カスタムボイス
+  type CustomVoiceItem = { voice_id: string; label: string; vendor_id: string; created_at?: string };
+  const [customVoices, setCustomVoices] = useState<CustomVoiceItem[]>([]);
+  const [customVoicesLoading, setCustomVoicesLoading] = useState(false);
+  const [cvName, setCvName] = useState("");
+  const [cvRecording, setCvRecording] = useState(false);
+  const [cvRecordSeconds, setCvRecordSeconds] = useState(0);
+  const [cvRegistering, setCvRegistering] = useState(false);
+  const cvTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const cvWavPathRef = useRef<string>("");
+  const CV_DURATION = 5;
+  const CV_GUIDE_TEXT = "以下の文章を、普段の声で読み上げてください：\n\n「こんにちは！今日はとてもいい天気ですね。一緒にお散歩に行きませんか？楽しいお話をたくさんしましょう。」";
+
+  const loadCustomVoices = async () => {
+    setCustomVoicesLoading(true);
+    try {
+      const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices`);
+      const data = await res.json();
+      setCustomVoices(data.voices ?? []);
+    } catch {
+      Alert.alert("エラー", "カスタムボイス一覧の取得に失敗しました");
+    } finally {
+      setCustomVoicesLoading(false);
+    }
+  };
+
+  const openCustomVoiceList = () => {
+    loadCustomVoices();
+    navigateTo("custom-voice-list");
+  };
+
+  const openCustomVoiceRecord = () => {
+    setCvName("");
+    setCvRecordSeconds(0);
+    setCvRecording(false);
+    cvWavPathRef.current = "";
+    navigateTo("custom-voice-record");
+  };
+
+  const startCvRecording = async () => {
+    try {
+      if (Platform.OS === "android") {
+        const granted = await (await import("react-native")).PermissionsAndroid.request(
+          (await import("react-native")).PermissionsAndroid.PERMISSIONS.RECORD_AUDIO
+        );
+        if (granted !== "granted") { Alert.alert("エラー", "マイクの権限が必要です"); return; }
+      } else {
+        const { status } = await Audio.requestPermissionsAsync();
+        if (status !== "granted") { Alert.alert("エラー", "マイクの権限が必要です"); return; }
+      }
+
+      await Audio.setAudioModeAsync({ allowsRecordingIOS: true, playsInSilentModeIOS: true });
+
+      const wavFile = "custom_voice_recording.wav";
+      AudioRecord.init({ sampleRate: 24000, channels: 1, bitsPerSample: 16, audioSource: 6, wavFile });
+      await AudioRecord.start();
+      setCvRecording(true);
+      setCvRecordSeconds(0);
+
+      cvTimerRef.current = setInterval(() => {
+        setCvRecordSeconds(prev => {
+          if (prev + 1 >= CV_DURATION) {
+            stopCvRecording();
+            return CV_DURATION;
+          }
+          return prev + 1;
+        });
+      }, 1000);
+    } catch (e: any) {
+      Alert.alert("エラー", `録音開始に失敗しました: ${e?.message ?? e}`);
+    }
+  };
+
+  const stopCvRecording = async () => {
+    if (cvTimerRef.current) { clearInterval(cvTimerRef.current); cvTimerRef.current = null; }
+    try {
+      const filePath = await AudioRecord.stop();
+      cvWavPathRef.current = filePath;
+    } catch {}
+    setCvRecording(false);
+    await Audio.setAudioModeAsync({ allowsRecordingIOS: false });
+  };
+
+  const registerCustomVoice = async () => {
+    if (!cvName.trim()) { Alert.alert("エラー", "ボイス名を入力してください"); return; }
+    if (!cvWavPathRef.current) { Alert.alert("エラー", "まず録音してください"); return; }
+
+    setCvRegistering(true);
+    try {
+      const filePath = cvWavPathRef.current.startsWith("file://") ? cvWavPathRef.current : `file://${cvWavPathRef.current}`;
+      const audioBase64 = await FileSystem.readAsStringAsync(filePath, { encoding: FileSystem.EncodingType.Base64 });
+
+      const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: cvName.trim().toLowerCase().replace(/\s+/g, "_"), audio_base64: audioBase64 }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error ?? `HTTP ${res.status}`);
+      }
+      const result = await res.json();
+      Alert.alert("登録完了", `「${result.name}」のボイスを作成しました！\n(${result.extraction_time_ms}ms)`);
+      navigateTo("custom-voice-list", "back");
+      loadCustomVoices();
+    } catch (e: any) {
+      Alert.alert("エラー", `ボイス登録に失敗しました: ${e?.message ?? e}`);
+    } finally {
+      setCvRegistering(false);
+    }
+  };
+
+  const deleteCustomVoice = (voiceId: string) => {
+    Alert.alert("削除確認", "このカスタムボイスを削除しますか？", [
+      { text: "キャンセル", style: "cancel" },
+      {
+        text: "削除する", style: "destructive",
+        onPress: async () => {
+          try {
+            await fetch(`${DEVICE_SETTING_URL}/custom-voices/${encodeURIComponent(voiceId)}`, { method: "DELETE" });
+            setCustomVoices(prev => prev.filter(v => v.voice_id !== voiceId));
+          } catch {
+            Alert.alert("エラー", "削除に失敗しました");
+          }
+        },
+      },
+    ]);
+  };
+
   const openCharacterList = () => {
     navigateTo("character-list");
     loadCharacters();
@@ -343,6 +475,115 @@ export default function Settings() {
       setSaving(false);
     }
   };
+
+  // ---- カスタムボイス録音画面 ----
+  if (screen === "custom-voice-record") {
+    const progress = cvRecordSeconds / CV_DURATION;
+    return (
+      <SafeAreaView style={s.root}>
+        <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
+          <View style={s.header}>
+            <TouchableOpacity onPress={() => { if (cvRecording) stopCvRecording(); navigateTo("custom-voice-list", "back"); }} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+              <Text style={s.back}>←</Text>
+            </TouchableOpacity>
+            <Text style={s.headerTitle}>ボイスを録音</Text>
+          </View>
+          <ScrollView contentContainerStyle={[s.wrap, { alignItems: "center", paddingTop: 32 }]}>
+            <Text style={{ fontSize: 24, fontWeight: "700", color: "#333", marginBottom: 24 }}>あなたの声を録音しよう!</Text>
+            <View style={{ backgroundColor: "#f0f7ff", borderRadius: 16, padding: 20, marginBottom: 24, width: "100%" }}>
+              <Text style={{ fontSize: 15, color: "#555", lineHeight: 24 }}>{CV_GUIDE_TEXT}</Text>
+            </View>
+
+            <TextInput
+              style={[s.input, { width: "100%", marginBottom: 20, textAlign: "center", fontSize: 18 }]}
+              placeholder="ボイスの名前（例: パパ、ママ）"
+              value={cvName}
+              onChangeText={setCvName}
+            />
+
+            {/* プログレスバー */}
+            <View style={{ width: "100%", height: 8, backgroundColor: "#e0e0e0", borderRadius: 4, marginBottom: 8 }}>
+              <View style={{ width: `${progress * 100}%`, height: "100%", backgroundColor: cvRecording ? "#FF3B30" : "#007AFF", borderRadius: 4 }} />
+            </View>
+            <Text style={{ fontSize: 14, color: "#999", marginBottom: 20 }}>
+              {cvRecording ? `録音中... ${cvRecordSeconds}/${CV_DURATION}秒` : cvRecordSeconds >= CV_DURATION ? "録音完了!" : `${CV_DURATION}秒間録音します`}
+            </Text>
+
+            {/* 録音ボタン */}
+            {cvRecordSeconds < CV_DURATION ? (
+              <TouchableOpacity
+                style={{ width: 80, height: 80, borderRadius: 40, backgroundColor: cvRecording ? "#FF3B30" : "#007AFF", justifyContent: "center", alignItems: "center", marginBottom: 32 }}
+                onPress={cvRecording ? stopCvRecording : startCvRecording}
+              >
+                {cvRecording ? (
+                  <View style={{ width: 24, height: 24, backgroundColor: "#fff", borderRadius: 4 }} />
+                ) : (
+                  <View style={{ width: 24, height: 24, borderRadius: 12, backgroundColor: "#fff" }} />
+                )}
+              </TouchableOpacity>
+            ) : (
+              <TouchableOpacity
+                style={[s.button, { width: "100%", marginBottom: 16, backgroundColor: cvRegistering ? "#ccc" : "#007AFF" }]}
+                onPress={registerCustomVoice}
+                disabled={cvRegistering}
+              >
+                {cvRegistering ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <Text style={s.buttonText}>このボイスで登録する</Text>
+                )}
+              </TouchableOpacity>
+            )}
+
+            {cvRecordSeconds >= CV_DURATION && !cvRegistering && (
+              <TouchableOpacity onPress={() => { setCvRecordSeconds(0); cvChunksRef.current = []; }}>
+                <Text style={{ color: "#007AFF", fontSize: 15 }}>もう一度録音する</Text>
+              </TouchableOpacity>
+            )}
+          </ScrollView>
+        </Animated.View>
+      </SafeAreaView>
+    );
+  }
+
+  // ---- カスタムボイス一覧画面 ----
+  if (screen === "custom-voice-list") {
+    return (
+      <SafeAreaView style={s.root}>
+        <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
+          <View style={s.header}>
+            <TouchableOpacity onPress={() => navigateTo("main", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+              <Text style={s.back}>←</Text>
+            </TouchableOpacity>
+            <Text style={s.headerTitle}>カスタムボイス</Text>
+          </View>
+          <ScrollView contentContainerStyle={s.wrap}>
+            {customVoicesLoading ? (
+              <ActivityIndicator style={{ marginTop: 32 }} />
+            ) : customVoices.length === 0 ? (
+              <Text style={{ textAlign: "center", color: "#999", marginTop: 32, fontSize: 15 }}>まだカスタムボイスがありません</Text>
+            ) : (
+              customVoices.map(v => (
+                <View key={v.voice_id} style={[s.navRow, { flexDirection: "column", alignItems: "flex-start", gap: 4 }]}>
+                  <View style={{ flexDirection: "row", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
+                    <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>{v.label}</Text>
+                    <TouchableOpacity onPress={() => deleteCustomVoice(v.voice_id)}>
+                      <Text style={{ color: "#FF3B30", fontSize: 14 }}>削除</Text>
+                    </TouchableOpacity>
+                  </View>
+                  <Text style={{ fontSize: 12, color: "#999" }}>ID: {v.voice_id}</Text>
+                </View>
+              ))
+            )}
+
+            <TouchableOpacity style={[s.button, { marginTop: 24 }]} onPress={openCustomVoiceRecord}>
+              <Text style={s.buttonText}>+ カスタムボイスを作成</Text>
+            </TouchableOpacity>
+          </ScrollView>
+        </Animated.View>
+      </SafeAreaView>
+    );
+  }
 
   // ---- 利用状況詳細画面（日次） ----
   if (screen === "usage-detail") {
@@ -961,6 +1202,11 @@ export default function Settings() {
 
           <TouchableOpacity style={s.navRow} onPress={openCharacterList}>
             <Text style={s.navText}>キャラクター管理</Text>
+            <Text style={s.chevron}>›</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity style={s.navRow} onPress={openCustomVoiceList}>
+            <Text style={s.navText}>カスタムボイス管理</Text>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
 

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -673,7 +673,7 @@ export default function Settings() {
             <TouchableOpacity onPress={() => navigateTo("main", "back")} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
               <Text style={s.back}>←</Text>
             </TouchableOpacity>
-            <Text style={s.headerTitle}>カスタムボイス</Text>
+            <Text style={s.headerTitle}>カスタムボイス（β）</Text>
           </View>
           <ScrollView contentContainerStyle={s.wrap} keyboardShouldPersistTaps="handled">
             {customVoicesLoading ? (
@@ -1060,13 +1060,13 @@ export default function Settings() {
     }
   }
   if (zakicorpSystem.length > 0) {
-    voiceSections.push({ title: "ZakiCorp（システム）", data: zakicorpSystem });
+    voiceSections.push({ title: "ZakiCorp（システム）※ベータ版", data: zakicorpSystem });
   }
   const customAsVoice = customVoices
     .filter(v => v.owner_id !== "system")
     .map(v => ({ voice_id: v.voice_id, label: v.label, provider: "ZakiCorp", vendor_id: v.vendor_id }));
   if (customAsVoice.length > 0) {
-    voiceSections.push({ title: "ZakiCorp（カスタム）", data: customAsVoice });
+    voiceSections.push({ title: "ZakiCorp（カスタム）※ベータ版", data: customAsVoice });
   }
 
   const currentVoiceLabel = () => {
@@ -1338,7 +1338,7 @@ export default function Settings() {
           </TouchableOpacity>
 
           <TouchableOpacity style={s.navRow} onPress={openCustomVoiceList}>
-            <Text style={s.navText}>カスタムボイス管理</Text>
+            <Text style={s.navText}>カスタムボイス管理（β）</Text>
             <Text style={s.chevron}>›</Text>
           </TouchableOpacity>
 

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -282,9 +282,10 @@ export default function Settings() {
   const CV_GUIDE_TEXT = "以下の文章を、普段の声で読み上げてください：\n\n「こんにちは！今日はとてもいい天気ですね。一緒にお散歩に行きませんか？楽しいお話をたくさんしましょう。」";
 
   const loadCustomVoices = async () => {
+    if (!ownerId) return;
     setCustomVoicesLoading(true);
     try {
-      const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices`);
+      const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices?owner_id=${encodeURIComponent(ownerId)}`);
       const data = await res.json();
       setCustomVoices(data.voices ?? []);
     } catch {
@@ -363,7 +364,7 @@ export default function Settings() {
       const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: cvName.trim().toLowerCase().replace(/\s+/g, "_"), audio_base64: audioBase64 }),
+        body: JSON.stringify({ name: cvName.trim().toLowerCase().replace(/\s+/g, "_"), audio_base64: audioBase64, owner_id: ownerId }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
@@ -548,6 +549,23 @@ export default function Settings() {
 
   // ---- カスタムボイス一覧画面 ----
   if (screen === "custom-voice-list") {
+    const systemVoices = customVoices.filter(v => (v as any).owner_id === "system");
+    const userVoices = customVoices.filter(v => (v as any).owner_id !== "system");
+
+    const renderVoiceRow = (v: CustomVoiceItem, deletable: boolean) => (
+      <View key={v.voice_id} style={[s.navRow, { flexDirection: "column", alignItems: "flex-start", gap: 4 }]}>
+        <View style={{ flexDirection: "row", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
+          <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>{v.label}</Text>
+          {deletable && (
+            <TouchableOpacity onPress={() => deleteCustomVoice(v.voice_id)}>
+              <Text style={{ color: "#FF3B30", fontSize: 14 }}>削除</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+        <Text style={{ fontSize: 12, color: "#999" }}>ID: {v.voice_id}</Text>
+      </View>
+    );
+
     return (
       <SafeAreaView style={s.root}>
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
@@ -560,20 +578,21 @@ export default function Settings() {
           <ScrollView contentContainerStyle={s.wrap}>
             {customVoicesLoading ? (
               <ActivityIndicator style={{ marginTop: 32 }} />
-            ) : customVoices.length === 0 ? (
-              <Text style={{ textAlign: "center", color: "#999", marginTop: 32, fontSize: 15 }}>まだカスタムボイスがありません</Text>
             ) : (
-              customVoices.map(v => (
-                <View key={v.voice_id} style={[s.navRow, { flexDirection: "column", alignItems: "flex-start", gap: 4 }]}>
-                  <View style={{ flexDirection: "row", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
-                    <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>{v.label}</Text>
-                    <TouchableOpacity onPress={() => deleteCustomVoice(v.voice_id)}>
-                      <Text style={{ color: "#FF3B30", fontSize: 14 }}>削除</Text>
-                    </TouchableOpacity>
-                  </View>
-                  <Text style={{ fontSize: 12, color: "#999" }}>ID: {v.voice_id}</Text>
-                </View>
-              ))
+              <>
+                {systemVoices.length > 0 && (
+                  <>
+                    <Text style={{ fontSize: 13, fontWeight: "600", color: "#999", marginTop: 16, marginBottom: 8 }}>ZakiCorp（システム）</Text>
+                    {systemVoices.map(v => renderVoiceRow(v, false))}
+                  </>
+                )}
+                <Text style={{ fontSize: 13, fontWeight: "600", color: "#999", marginTop: 20, marginBottom: 8 }}>ZakiCorp（カスタム）</Text>
+                {userVoices.length === 0 ? (
+                  <Text style={{ textAlign: "center", color: "#bbb", marginTop: 12, fontSize: 14 }}>まだカスタムボイスがありません</Text>
+                ) : (
+                  userVoices.map(v => renderVoiceRow(v, true))
+                )}
+              </>
             )}
 
             <TouchableOpacity style={[s.button, { marginTop: 24 }]} onPress={openCustomVoiceRecord}>

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -19,6 +19,7 @@ import { useEffect, useRef, useState } from "react";
 import { useOwnerId } from "../../hooks/useOwnerId";
 import AudioRecord from "react-native-audio-record";
 import { Audio } from "expo-av";
+import * as DocumentPicker from "expo-document-picker";
 import * as FileSystem from "expo-file-system";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
@@ -280,6 +281,7 @@ export default function Settings() {
   const cvWavPathRef = useRef<string>("");
   const [editingVoiceId, setEditingVoiceId] = useState<string | null>(null);
   const [editingVoiceLabel, setEditingVoiceLabel] = useState("");
+  const [cvUploadedFile, setCvUploadedFile] = useState<{ uri: string; name: string; mimeType: string; durationSec: number } | null>(null);
   const CV_DURATION = 5;
   const CV_GUIDE_TEXT = "以下の文章を、普段の声で読み上げてください：\n\n「こんにちは！今日はとてもいい天気ですね。一緒にお散歩に行きませんか？楽しいお話をたくさんしましょう。」";
 
@@ -307,6 +309,7 @@ export default function Settings() {
     setCvRecordSeconds(0);
     setCvRecording(false);
     cvWavPathRef.current = "";
+    setCvUploadedFile(null);
     navigateTo("custom-voice-record");
   };
 
@@ -356,17 +359,20 @@ export default function Settings() {
 
   const registerCustomVoice = async () => {
     if (!cvName.trim()) { Alert.alert("エラー", "ボイス名を入力してください"); return; }
-    if (!cvWavPathRef.current) { Alert.alert("エラー", "まず録音してください"); return; }
+    if (!cvWavPathRef.current && !cvUploadedFile) { Alert.alert("エラー", "まず録音するかファイルを選択してください"); return; }
 
     setCvRegistering(true);
     try {
-      const filePath = cvWavPathRef.current.startsWith("file://") ? cvWavPathRef.current : `file://${cvWavPathRef.current}`;
-      const audioBase64 = await FileSystem.readAsStringAsync(filePath, { encoding: FileSystem.EncodingType.Base64 });
+      const fileUri = cvUploadedFile
+        ? (cvUploadedFile.uri.startsWith("file://") ? cvUploadedFile.uri : `file://${cvUploadedFile.uri}`)
+        : (cvWavPathRef.current.startsWith("file://") ? cvWavPathRef.current : `file://${cvWavPathRef.current}`);
+      const audioBase64 = await FileSystem.readAsStringAsync(fileUri, { encoding: FileSystem.EncodingType.Base64 });
+      const mimeType = cvUploadedFile?.mimeType || "audio/wav";
 
       const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ label: cvName.trim(), audio_base64: audioBase64, owner_id: ownerId }),
+        body: JSON.stringify({ label: cvName.trim(), audio_base64: audioBase64, owner_id: ownerId, mime_type: mimeType }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
@@ -380,6 +386,43 @@ export default function Settings() {
       Alert.alert("エラー", `ボイス登録に失敗しました: ${e?.message ?? e}`);
     } finally {
       setCvRegistering(false);
+    }
+  };
+
+  const uploadCustomVoice = async () => {
+    if (!ownerId) return;
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        type: ["audio/*"],
+        copyToCacheDirectory: true,
+      });
+      if (result.canceled || !result.assets?.length) return;
+
+      const asset = result.assets[0];
+      const maxSize = 10 * 1024 * 1024;
+      if (asset.size && asset.size > maxSize) {
+        Alert.alert("エラー", "ファイルサイズは10MB以下にしてください");
+        return;
+      }
+
+      const { sound, status } = await Audio.Sound.createAsync({ uri: asset.uri });
+      const durationSec = ((status as any).durationMillis ?? 0) / 1000;
+      await sound.unloadAsync();
+
+      if (durationSec < 3 || durationSec > 20) {
+        Alert.alert("エラー", `音声の長さは3〜20秒にしてください（現在: ${durationSec.toFixed(1)}秒）`);
+        return;
+      }
+
+      const fileName = asset.name?.replace(/\.[^.]+$/, "") || "upload";
+      setCvUploadedFile({ uri: asset.uri, name: asset.name || "audio", mimeType: asset.mimeType || "audio/wav", durationSec });
+      setCvName(fileName);
+      setCvRecordSeconds(0);
+      setCvRecording(false);
+      cvWavPathRef.current = "";
+      navigateTo("custom-voice-record");
+    } catch (e: any) {
+      Alert.alert("エラー", `ファイル選択に失敗しました: ${e?.message ?? e}`);
     }
   };
 
@@ -479,23 +522,39 @@ export default function Settings() {
     }
   };
 
-  // ---- カスタムボイス録音画面 ----
+  // ---- カスタムボイス録音/アップロード画面 ----
   if (screen === "custom-voice-record") {
+    const isUpload = !!cvUploadedFile;
     const progress = cvRecordSeconds / CV_DURATION;
+    const canRegister = isUpload || cvRecordSeconds >= CV_DURATION;
     return (
       <SafeAreaView style={s.root}>
         <Animated.View style={[s.flex, { transform: [{ translateX: slideAnim }] }]}>
           <View style={s.header}>
-            <TouchableOpacity onPress={() => { if (cvRecording) stopCvRecording(); navigateTo("custom-voice-list", "back"); }} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
+            <TouchableOpacity onPress={() => { if (cvRecording) stopCvRecording(); setCvUploadedFile(null); navigateTo("custom-voice-list", "back"); }} hitSlop={{ top: 12, bottom: 12, left: 12, right: 24 }}>
               <Text style={s.back}>←</Text>
             </TouchableOpacity>
-            <Text style={s.headerTitle}>ボイスを録音</Text>
+            <Text style={s.headerTitle}>{isUpload ? "ファイルからボイス作成" : "ボイスを録音"}</Text>
           </View>
           <ScrollView contentContainerStyle={[s.wrap, { alignItems: "center", paddingTop: 32 }]}>
-            <Text style={{ fontSize: 24, fontWeight: "700", color: "#333", marginBottom: 24 }}>あなたの声を録音しよう!</Text>
-            <View style={{ backgroundColor: "#f0f7ff", borderRadius: 16, padding: 20, marginBottom: 24, width: "100%" }}>
-              <Text style={{ fontSize: 15, color: "#555", lineHeight: 24 }}>{CV_GUIDE_TEXT}</Text>
-            </View>
+            {isUpload ? (
+              <>
+                <Text style={{ fontSize: 24, fontWeight: "700", color: "#333", marginBottom: 24 }}>音声ファイルからボイス作成</Text>
+                <View style={{ backgroundColor: "#f0f7ff", borderRadius: 16, padding: 20, marginBottom: 24, width: "100%" }}>
+                  <Text style={{ fontSize: 15, color: "#555", lineHeight: 24 }}>
+                    ファイル: {cvUploadedFile.name}{"\n"}
+                    長さ: {cvUploadedFile.durationSec.toFixed(1)}秒
+                  </Text>
+                </View>
+              </>
+            ) : (
+              <>
+                <Text style={{ fontSize: 24, fontWeight: "700", color: "#333", marginBottom: 24 }}>あなたの声を録音しよう!</Text>
+                <View style={{ backgroundColor: "#f0f7ff", borderRadius: 16, padding: 20, marginBottom: 24, width: "100%" }}>
+                  <Text style={{ fontSize: 15, color: "#555", lineHeight: 24 }}>{CV_GUIDE_TEXT}</Text>
+                </View>
+              </>
+            )}
 
             <View style={{ flexDirection: "row", alignItems: "center", width: "100%", marginBottom: 20, gap: 10 }}>
               <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>ボイス名</Text>
@@ -507,16 +566,18 @@ export default function Settings() {
               />
             </View>
 
-            {/* プログレスバー */}
-            <View style={{ width: "100%", height: 8, backgroundColor: "#e0e0e0", borderRadius: 4, marginBottom: 8 }}>
-              <View style={{ width: `${progress * 100}%`, height: "100%", backgroundColor: cvRecording ? "#FF3B30" : "#007AFF", borderRadius: 4 }} />
-            </View>
-            <Text style={{ fontSize: 14, color: "#999", marginBottom: 20 }}>
-              {cvRecording ? `録音中... ${cvRecordSeconds}/${CV_DURATION}秒` : cvRecordSeconds >= CV_DURATION ? "録音完了!" : `${CV_DURATION}秒間録音します`}
-            </Text>
+            {!isUpload && (
+              <>
+                <View style={{ width: "100%", height: 8, backgroundColor: "#e0e0e0", borderRadius: 4, marginBottom: 8 }}>
+                  <View style={{ width: `${progress * 100}%`, height: "100%", backgroundColor: cvRecording ? "#FF3B30" : "#007AFF", borderRadius: 4 }} />
+                </View>
+                <Text style={{ fontSize: 14, color: "#999", marginBottom: 20 }}>
+                  {cvRecording ? `録音中... ${cvRecordSeconds}/${CV_DURATION}秒` : cvRecordSeconds >= CV_DURATION ? "録音完了!" : `${CV_DURATION}秒間録音します`}
+                </Text>
+              </>
+            )}
 
-            {/* 録音ボタン */}
-            {cvRecordSeconds < CV_DURATION ? (
+            {!isUpload && cvRecordSeconds < CV_DURATION ? (
               <TouchableOpacity
                 style={{ width: 80, height: 80, borderRadius: 40, backgroundColor: cvRecording ? "#FF3B30" : "#007AFF", justifyContent: "center", alignItems: "center", marginBottom: 32 }}
                 onPress={cvRecording ? stopCvRecording : startCvRecording}
@@ -527,7 +588,7 @@ export default function Settings() {
                   <View style={{ width: 24, height: 24, borderRadius: 12, backgroundColor: "#fff" }} />
                 )}
               </TouchableOpacity>
-            ) : (
+            ) : canRegister ? (
               <TouchableOpacity
                 style={[s.button, { width: "100%", marginBottom: 16, backgroundColor: cvRegistering ? "#ccc" : "#007AFF" }]}
                 onPress={registerCustomVoice}
@@ -539,10 +600,10 @@ export default function Settings() {
                   <Text style={s.buttonText}>このボイスで登録する</Text>
                 )}
               </TouchableOpacity>
-            )}
+            ) : null}
 
-            {cvRecordSeconds >= CV_DURATION && !cvRegistering && (
-              <TouchableOpacity onPress={() => { setCvRecordSeconds(0); cvChunksRef.current = []; }}>
+            {!isUpload && cvRecordSeconds >= CV_DURATION && !cvRegistering && (
+              <TouchableOpacity onPress={() => { setCvRecordSeconds(0); cvWavPathRef.current = ""; }}>
                 <Text style={{ color: "#007AFF", fontSize: 15 }}>もう一度録音する</Text>
               </TouchableOpacity>
             )}
@@ -624,7 +685,10 @@ export default function Settings() {
             )}
 
             <TouchableOpacity style={[s.button, { marginTop: 24 }]} onPress={openCustomVoiceRecord}>
-              <Text style={s.buttonText}>+ カスタムボイスを作成</Text>
+              <Text style={s.buttonText}>+ 録音して作成</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={[s.button, { marginTop: 10, backgroundColor: "#34C759" }]} onPress={uploadCustomVoice}>
+              <Text style={s.buttonText}>+ ファイルから作成</Text>
             </TouchableOpacity>
           </ScrollView>
         </Animated.View>
@@ -906,6 +970,7 @@ export default function Settings() {
         </View>
         <ScrollView contentContainerStyle={s.wrap}>
           {[
+            { ver: "0.8.1", date: "20260510", desc: "相槌機能追加、サーチ機能追加、クローンボイス機能追加、再生終了後に即録音状態になるよう改修、アプリの録音ボタン押下後に即録音状態になるよう改修" },
             { ver: "0.8.0", date: "20260426", desc: "ずんだもんボイス等追加、LLM選択機能追加、コストページ追加、STT文字起こし中に途中で切れてしまう問題を改善" },
             { ver: "0.7.1", date: "20260328", desc: "複数デバイスの登録機能追加" },
             { ver: "0.7.0", date: "20260322", desc: "キャラクターシステム追加、会話ログ機能追加、UI刷新" },

--- a/app/app/(tabs)/settings.tsx
+++ b/app/app/(tabs)/settings.tsx
@@ -269,7 +269,7 @@ export default function Settings() {
   };
 
   // カスタムボイス
-  type CustomVoiceItem = { voice_id: string; label: string; vendor_id: string; created_at?: string };
+  type CustomVoiceItem = { voice_id: string; label: string; vendor_id: string; owner_id?: string; created_at?: string };
   const [customVoices, setCustomVoices] = useState<CustomVoiceItem[]>([]);
   const [customVoicesLoading, setCustomVoicesLoading] = useState(false);
   const [cvName, setCvName] = useState("");
@@ -364,14 +364,14 @@ export default function Settings() {
       const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: cvName.trim().toLowerCase().replace(/\s+/g, "_"), audio_base64: audioBase64, owner_id: ownerId }),
+        body: JSON.stringify({ label: cvName.trim(), audio_base64: audioBase64, owner_id: ownerId }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         throw new Error(err.error ?? `HTTP ${res.status}`);
       }
       const result = await res.json();
-      Alert.alert("登録完了", `「${result.name}」のボイスを作成しました！\n(${result.extraction_time_ms}ms)`);
+      Alert.alert("登録完了", `「${result.label}」のボイスを作成しました！\n(${result.extraction_time_ms}ms)`);
       navigateTo("custom-voice-list", "back");
       loadCustomVoices();
     } catch (e: any) {
@@ -549,20 +549,66 @@ export default function Settings() {
 
   // ---- カスタムボイス一覧画面 ----
   if (screen === "custom-voice-list") {
-    const systemVoices = customVoices.filter(v => (v as any).owner_id === "system");
-    const userVoices = customVoices.filter(v => (v as any).owner_id !== "system");
+    const systemVoices = customVoices.filter(v => v.owner_id === "system");
+    const userVoices = customVoices.filter(v => v.owner_id !== "system");
 
-    const renderVoiceRow = (v: CustomVoiceItem, deletable: boolean) => (
+    const [editingVoiceId, setEditingVoiceId] = useState<string | null>(null);
+    const [editingVoiceLabel, setEditingVoiceLabel] = useState("");
+
+    const startRename = (voiceId: string, currentLabel: string) => {
+      setEditingVoiceId(voiceId);
+      setEditingVoiceLabel(currentLabel);
+    };
+
+    const submitRename = async () => {
+      if (!editingVoiceId || !editingVoiceLabel.trim()) return;
+      try {
+        const res = await fetch(`${DEVICE_SETTING_URL}/custom-voices/${encodeURIComponent(editingVoiceId)}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label: editingVoiceLabel.trim() }),
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        setCustomVoices(prev => prev.map(v => v.voice_id === editingVoiceId ? { ...v, label: editingVoiceLabel.trim() } : v));
+      } catch {
+        Alert.alert("エラー", "名前の変更に失敗しました");
+      }
+      setEditingVoiceId(null);
+    };
+
+    const renderVoiceRow = (v: CustomVoiceItem, editable: boolean) => (
       <View key={v.voice_id} style={[s.navRow, { flexDirection: "column", alignItems: "flex-start", gap: 4 }]}>
-        <View style={{ flexDirection: "row", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
-          <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>{v.label}</Text>
-          {deletable && (
-            <TouchableOpacity onPress={() => deleteCustomVoice(v.voice_id)}>
-              <Text style={{ color: "#FF3B30", fontSize: 14 }}>削除</Text>
+        {editingVoiceId === v.voice_id ? (
+          <View style={{ flexDirection: "row", width: "100%", alignItems: "center", gap: 8 }}>
+            <TextInput
+              style={[s.input, { flex: 1, marginBottom: 0 }]}
+              value={editingVoiceLabel}
+              onChangeText={setEditingVoiceLabel}
+              autoFocus
+              onSubmitEditing={submitRename}
+            />
+            <TouchableOpacity onPress={submitRename}>
+              <Text style={{ color: "#007AFF", fontSize: 14, fontWeight: "600" }}>保存</Text>
             </TouchableOpacity>
-          )}
-        </View>
-        <Text style={{ fontSize: 12, color: "#999" }}>ID: {v.voice_id}</Text>
+            <TouchableOpacity onPress={() => setEditingVoiceId(null)}>
+              <Text style={{ color: "#999", fontSize: 14 }}>取消</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <View style={{ flexDirection: "row", justifyContent: "space-between", width: "100%", alignItems: "center" }}>
+            <Text style={{ fontSize: 16, fontWeight: "600", color: "#333" }}>{v.label}</Text>
+            {editable && (
+              <View style={{ flexDirection: "row", gap: 16 }}>
+                <TouchableOpacity onPress={() => startRename(v.voice_id, v.label)}>
+                  <Text style={{ color: "#007AFF", fontSize: 14 }}>編集</Text>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={() => deleteCustomVoice(v.voice_id)}>
+                  <Text style={{ color: "#FF3B30", fontSize: 14 }}>削除</Text>
+                </TouchableOpacity>
+              </View>
+            )}
+          </View>
+        )}
       </View>
     );
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -23,6 +23,7 @@
         "expo-av": "^15.1.7",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.7",
+        "expo-document-picker": "~13.1.6",
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
@@ -6865,6 +6866,15 @@
       "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.10.0.tgz",
       "integrity": "sha512-NxtM/qot5Rh2cY333iOE87dDg1S8CibW+Wu4WdLua3UMjy81pXYzAGCZGNOeY7k9GpNFqDPNDXWyBSlk9r2pBg==",
       "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-13.1.6.tgz",
+      "integrity": "sha512-8FTQPDOkyCvFN/i4xyqzH7ELW4AsB6B3XBZQjn1FEdqpozo6rpNJRr7sWFU/93WrLgA9FJEKpKbyr6XxczK6BA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "expo-av": "^15.1.7",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.7",
+    "expo-document-picker": "~13.1.6",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",

--- a/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
+++ b/backend/toytalk-api-stream-for-esp32-lambda/index.mjs
@@ -1,6 +1,6 @@
   // Node.js 18+ / ESM（index.mjs）
   // Handler: index.handler
-  // Env: OPENAI_API_KEY, GOOGLE_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY, SAKURA_API_KEY
+  // Env: OPENAI_API_KEY, GOOGLE_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY, SAKURA_API_KEY, ZAKICORP_API_KEY, ZAKICORP_TTS_URL
   import OpenAI from "openai";
   import { createHash } from "node:crypto";
   import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
@@ -205,6 +205,7 @@
     ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
     FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
     Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
+    ZakiCorp:   { ttsVendor: "zakicorp",   ttsModel: "zakicorp-tts" },
   };
 
   // ---- LLMデフォルト（llm_id未設定時のフォールバック）----
@@ -452,6 +453,38 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
     return pcmBuffer;
   }
 
+  // ZakiCorp TTS (clone voice via local GPU) — streaming PCM to ESP32
+  async function ttsStreamZakiCorp(text, { speaker = "vivian", language = "Japanese" } = {}, res, segSeq) {
+    const key = process.env.ZAKICORP_API_KEY;
+    const baseUrl = process.env.ZAKICORP_TTS_URL;
+    if (!key || !baseUrl) throw new Error("ZAKICORP_API_KEY or ZAKICORP_TTS_URL is not set");
+    const resp = await fetch(`${baseUrl}/v1/tts/stream`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ text, language, speaker }),
+    });
+    if (!resp.ok) {
+      const errorText = await resp.text();
+      throw new Error(`ZakiCorp TTS failed: ${resp.status} ${errorText}`);
+    }
+    let totalBytes = 0;
+    let firstChunk = true;
+    for await (const raw of resp.body) {
+      const chunk = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);
+      if (firstChunk) {
+        sendMeta(res, "tts_start", { id: segSeq, size: 0, streaming: true });
+        firstChunk = false;
+      }
+      sendPCM(res, chunk);
+      totalBytes += chunk.length;
+    }
+    console.log(`[TTS ZakiCorp] streamed ${totalBytes} bytes, text="${text}"`);
+    return totalBytes;
+  }
+
   // DynamoDBからdevice_idに紐づくキャラクター＆ボイス設定を解決
   // 解決チェーン: device → character(voice_id + personality_prompt) → voice(provider + vendor_id)
   async function resolveCharacterFromDynamo(deviceId) {
@@ -540,6 +573,7 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
       if (s.includes("elevenlabs"))  return "ElevenLabs";
       if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
       if (s.includes("sakura"))    return "Sakura";
+      if (s.includes("zakicorp") || s.includes("qwen")) return "ZakiCorp";
       return undefined;
     }
 
@@ -835,14 +869,18 @@ async function ttsBufferOpenAI(text, voice, ttsModel) {
         } else if (cfg.ttsVendor === "sakura") {
           const modelName = voice === "default" ? "zundamon" : voice;
           pcmBuffer = await ttsBufferSakura(t, { model: modelName });
+        } else if (cfg.ttsVendor === "zakicorp") {
+          const speaker = voice === "default" ? "vivian" : voice;
+          await ttsStreamZakiCorp(t, { speaker }, res, segSeq);
+          pcmBuffer = null;
         } else {
           throw new Error("Unknown ttsVendor");
         }
-        // メタデータでチャンク情報を送信
-        sendMeta(res, "tts_start", { id: segSeq, size: pcmBuffer.length });
-        // PCMバイナリを直接送信
-        sendPCM(res, pcmBuffer);
-        console.log(`[Lambda] id=${segSeq}, pcm.length=${pcmBuffer.length} bytes, text="${t}"`);
+        if (pcmBuffer) {
+          sendMeta(res, "tts_start", { id: segSeq, size: pcmBuffer.length });
+          sendPCM(res, pcmBuffer);
+          console.log(`[Lambda] id=${segSeq}, pcm.length=${pcmBuffer.length} bytes, text="${t}"`);
+        }
       } catch (e) {
         sendMeta(res, "error", { message: `TTS failed: ${e?.message || e}` });
       }

--- a/backend/toytalk-stream-handler-lambda/index.mjs
+++ b/backend/toytalk-stream-handler-lambda/index.mjs
@@ -1,6 +1,6 @@
   // Node.js 18+ / ESM（index.mjs）
   // Handler: index.handler
-  // Env: OPENAI_API_KEY, GOOGLE_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY
+  // Env: OPENAI_API_KEY, GOOGLE_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY, ZAKICORP_API_KEY, ZAKICORP_TTS_URL
   import OpenAI from "openai";
   import { createHash } from "node:crypto";
   import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
@@ -192,6 +192,7 @@
     ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
     FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
     Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
+    ZakiCorp:   { ttsVendor: "zakicorp",   ttsModel: "zakicorp-tts" },
   };
 
   // ---- LLMデフォルト（llm_id未設定時のフォールバック）----
@@ -499,6 +500,48 @@
     return wavBuffer.toString("base64");
   }
 
+  function pcmToWavBase64(pcmBuf, sampleRate = 24000, channels = 1) {
+    const wav = Buffer.alloc(44 + pcmBuf.length);
+    wav.write("RIFF", 0);
+    wav.writeUInt32LE(36 + pcmBuf.length, 4);
+    wav.write("WAVE", 8);
+    wav.write("fmt ", 12);
+    wav.writeUInt32LE(16, 16);
+    wav.writeUInt16LE(1, 20);
+    wav.writeUInt16LE(channels, 22);
+    wav.writeUInt32LE(sampleRate, 24);
+    wav.writeUInt32LE(sampleRate * channels * 2, 28);
+    wav.writeUInt16LE(channels * 2, 32);
+    wav.writeUInt16LE(16, 34);
+    wav.write("data", 36);
+    wav.writeUInt32LE(pcmBuf.length, 40);
+    pcmBuf.copy(wav, 44);
+    return wav.toString("base64");
+  }
+
+  // ZakiCorp TTS (clone voice via local GPU) — streaming chunks
+  async function ttsToBase64ZakiCorp(text, { speaker = "vivian", language = "Japanese" } = {}) {
+    const key = process.env.ZAKICORP_API_KEY;
+    const baseUrl = process.env.ZAKICORP_TTS_URL;
+    if (!key || !baseUrl) throw new Error("ZAKICORP_API_KEY or ZAKICORP_TTS_URL is not set");
+    const resp = await fetch(`${baseUrl}/v1/tts/stream`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ text, language, speaker }),
+    });
+    if (!resp.ok) {
+      const errorText = await resp.text();
+      throw new Error(`ZakiCorp TTS failed: ${resp.status} ${errorText}`);
+    }
+    const sampleRate = parseInt(resp.headers.get("X-Sample-Rate") || "24000");
+    const channels = parseInt(resp.headers.get("X-Channels") || "1");
+    const pcmBuf = Buffer.from(await resp.arrayBuffer());
+    return pcmToWavBase64(pcmBuf, sampleRate, channels);
+  }
+
   async function resolveCharacterFromDynamo(characterId) {
     try {
       const charRes = await ddb.send(new GetCommand({
@@ -603,6 +646,7 @@
       if (s.includes("elevenlabs"))  return "ElevenLabs";
       if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
       if (s.includes("sakura"))      return "Sakura";
+      if (s.includes("zakicorp") || s.includes("qwen")) return "ZakiCorp";
       return undefined;
     }
 
@@ -867,6 +911,10 @@
         } else if (cfg.ttsVendor === "sakura") {
           const modelName = voice === "default" ? "zundamon" : voice;
           b64 = await ttsToBase64Sakura(t, { model: modelName });
+          fmt = "wav";
+        } else if (cfg.ttsVendor === "zakicorp") {
+          const speaker = voice === "default" ? "vivian" : voice;
+          b64 = await ttsToBase64ZakiCorp(t, { speaker });
           fmt = "wav";
         } else {
           throw new Error("Unknown ttsVendor");

--- a/backend/toytalker-backchannel-for-app-lambda/index.mjs
+++ b/backend/toytalker-backchannel-for-app-lambda/index.mjs
@@ -1,6 +1,6 @@
 // Node.js 18+ / ESM（index.mjs）
 // Handler: index.handler
-// Env: ANTHROPIC_API_KEY, SAKURA_API_KEY, GOOGLE_API_KEY, OPENAI_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY
+// Env: ANTHROPIC_API_KEY, SAKURA_API_KEY, GOOGLE_API_KEY, OPENAI_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY, ZAKICORP_API_KEY, ZAKICORP_TTS_URL
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 
@@ -17,6 +17,7 @@ const TTS_TABLE = {
   ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
   FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
   Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
+  ZakiCorp:   { ttsVendor: "zakicorp",   ttsModel: "zakicorp-tts" },
 };
 const TTS_DEFAULT = "Sakura";
 
@@ -29,6 +30,7 @@ function normalizeModelKey(k) {
   if (s.includes("elevenlabs"))  return "ElevenLabs";
   if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
   if (s.includes("sakura"))      return "Sakura";
+  if (s.includes("zakicorp") || s.includes("qwen")) return "ZakiCorp";
   return undefined;
 }
 
@@ -243,6 +245,30 @@ async function ttsToBase64FishAudio(text, { referenceId = "e58b0d7efca34eb38d5c4
   return wavBuffer.toString("base64");
 }
 
+// ZakiCorp TTS (clone voice via local GPU) → base64(WAV)
+async function ttsToBase64ZakiCorp(text, { speaker = "vivian", language = "Japanese" } = {}) {
+  const key = process.env.ZAKICORP_API_KEY;
+  const baseUrl = process.env.ZAKICORP_TTS_URL;
+  if (!key || !baseUrl) throw new Error("ZAKICORP_API_KEY or ZAKICORP_TTS_URL is not set");
+  const resp = await fetch(`${baseUrl}/v1/tts/stream`, {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ text, language, speaker }),
+  });
+  if (!resp.ok) throw new Error(`ZakiCorp TTS failed: ${resp.status} ${await resp.text()}`);
+  const sampleRate = parseInt(resp.headers.get("X-Sample-Rate") || "24000");
+  const pcmBuf = Buffer.from(await resp.arrayBuffer());
+  const wav = Buffer.alloc(44 + pcmBuf.length);
+  wav.write("RIFF", 0); wav.writeUInt32LE(36 + pcmBuf.length, 4);
+  wav.write("WAVE", 8); wav.write("fmt ", 12); wav.writeUInt32LE(16, 16);
+  wav.writeUInt16LE(1, 20); wav.writeUInt16LE(1, 22);
+  wav.writeUInt32LE(sampleRate, 24); wav.writeUInt32LE(sampleRate * 2, 28);
+  wav.writeUInt16LE(2, 32); wav.writeUInt16LE(16, 34);
+  wav.write("data", 36); wav.writeUInt32LE(pcmBuf.length, 40);
+  pcmBuf.copy(wav, 44);
+  return wav.toString("base64");
+}
+
 // ---- TTS ルーティング ----
 async function generateTTS(text, vendor, voice) {
   switch (vendor) {
@@ -252,6 +278,7 @@ async function generateTTS(text, vendor, voice) {
     case "gemini":     return ttsToBase64Gemini(text, { voiceName: voice || "Kore" });
     case "elevenlabs": return ttsToBase64ElevenLabs(text, { voiceId: voice });
     case "fishaudio":  return ttsToBase64FishAudio(text, { referenceId: voice });
+    case "zakicorp":   return ttsToBase64ZakiCorp(text, { speaker: voice || "vivian" });
     default:           return ttsToBase64Sakura(text, { model: "zundamon" });
   }
 }

--- a/backend/toytalker-backchannel-for-esp32-lambda/index.mjs
+++ b/backend/toytalker-backchannel-for-esp32-lambda/index.mjs
@@ -2,7 +2,7 @@
 // Handler: index.handler
 // ESP32向け相槌Lambda: raw PCMバイナリをレスポンスボディで返す
 // ヘッダ X-Backchannel-Text に相槌テキストを格納
-// Env: GOOGLE_API_KEY, OPENAI_API_KEY, SAKURA_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY
+// Env: GOOGLE_API_KEY, OPENAI_API_KEY, SAKURA_API_KEY, ELEVENLABS_API_KEY, FISHAUDIO_API_KEY, ZAKICORP_API_KEY, ZAKICORP_TTS_URL
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand } from "@aws-sdk/lib-dynamodb";
 
@@ -20,6 +20,7 @@ const TTS_TABLE = {
   ElevenLabs: { ttsVendor: "elevenlabs", ttsModel: "eleven_turbo_v2_5" },
   FishAudio:  { ttsVendor: "fishaudio",  ttsModel: "fishaudio" },
   Sakura:     { ttsVendor: "sakura",     ttsModel: "sakura" },
+  ZakiCorp:   { ttsVendor: "zakicorp",   ttsModel: "zakicorp-tts" },
 };
 const TTS_DEFAULT = "Sakura";
 
@@ -32,6 +33,7 @@ function normalizeModelKey(k) {
   if (s.includes("elevenlabs"))  return "ElevenLabs";
   if (s.includes("fishaudio") || s.includes("fish")) return "FishAudio";
   if (s.includes("sakura"))      return "Sakura";
+  if (s.includes("zakicorp") || s.includes("qwen")) return "ZakiCorp";
   return undefined;
 }
 
@@ -244,6 +246,20 @@ async function ttsPcmSakura(text, { model = "zundamon", style = "normal" } = {})
   return wavBuffer.slice(44); // WAVヘッダ(44bytes)をスキップ
 }
 
+// ZakiCorp TTS (clone voice via local GPU) → raw PCM Buffer
+async function ttsPcmZakiCorp(text, { speaker = "vivian", language = "Japanese" } = {}) {
+  const key = process.env.ZAKICORP_API_KEY;
+  const baseUrl = process.env.ZAKICORP_TTS_URL;
+  if (!key || !baseUrl) throw new Error("ZAKICORP_API_KEY or ZAKICORP_TTS_URL is not set");
+  const resp = await fetch(`${baseUrl}/v1/tts/stream`, {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${key}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ text, language, speaker }),
+  });
+  if (!resp.ok) throw new Error(`ZakiCorp TTS failed: ${resp.status} ${await resp.text()}`);
+  return Buffer.from(await resp.arrayBuffer());
+}
+
 // ---- TTS ルーティング ----
 async function generateTTSPcm(text, vendor, voice) {
   switch (vendor) {
@@ -253,6 +269,7 @@ async function generateTTSPcm(text, vendor, voice) {
     case "gemini":     return ttsPcmGemini(text, { voiceName: voice || "Kore" });
     case "elevenlabs": return ttsPcmElevenLabs(text, { voiceId: voice });
     case "fishaudio":  return ttsPcmFishAudio(text, { referenceId: voice });
+    case "zakicorp":   return ttsPcmZakiCorp(text, { speaker: voice || "vivian" });
     default:           return ttsPcmSakura(text, { model: "zundamon" });
   }
 }

--- a/backend/toytalker-device-setting-lambda/deploy.sh
+++ b/backend/toytalker-device-setting-lambda/deploy.sh
@@ -5,7 +5,11 @@ echo "📦 Installing dependencies..."
 "/c/Program Files/nodejs/npm.cmd" install
 
 echo "📦 Bundling with esbuild..."
-"/c/Program Files/nodejs/npx.cmd" esbuild index.mjs --bundle --platform=node --format=cjs --outfile=bundle.js
+"/c/Program Files/nodejs/npx.cmd" esbuild index.mjs --bundle --platform=node --format=cjs \
+  --external:@aws-sdk/client-dynamodb \
+  --external:@aws-sdk/lib-dynamodb \
+  --external:@aws-sdk/client-s3 \
+  --outfile=bundle.js
 
 echo "📁 Creating zip..."
 mkdir -p temp_deploy

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -543,12 +543,14 @@ export const handler = async (event) => {
       return response(200, { date, conversations });
     }
 
-    // ---- GET /custom-voices ---- ZakiCorpカスタムボイス一覧
+    // ---- GET /custom-voices ---- ZakiCorpボイス一覧（system + 自分のカスタム）
     if (method === "GET" && path === "/custom-voices") {
+      const userId = event.queryStringParameters?.owner_id;
+      if (!userId) return response(400, { error: "owner_id is required" });
       const result = await ddb.send(new ScanCommand({
         TableName: VOICES_TABLE,
-        FilterExpression: "provider = :p",
-        ExpressionAttributeValues: { ":p": "ZakiCorp" },
+        FilterExpression: "provider = :p AND (owner_id = :system OR owner_id = :userId)",
+        ExpressionAttributeValues: { ":p": "ZakiCorp", ":system": "system", ":userId": userId },
       }));
       return response(200, { voices: result.Items ?? [] });
     }
@@ -556,18 +558,21 @@ export const handler = async (event) => {
     // ---- POST /custom-voices ---- カスタムボイス登録
     if (method === "POST" && path === "/custom-voices") {
       const body = JSON.parse(event.body ?? "{}");
-      const { name, audio_base64 } = body;
+      const { name, audio_base64, owner_id } = body;
       if (!name || !audio_base64) return response(400, { error: "name and audio_base64 are required" });
+      if (!owner_id) return response(400, { error: "owner_id is required" });
 
       const apiKey = process.env.ZAKICORP_API_KEY;
       const baseUrl = process.env.ZAKICORP_TTS_URL;
       if (!apiKey || !baseUrl) return response(500, { error: "ZakiCorp TTS not configured" });
 
+      const speakerName = `${owner_id}_${name}`;
+
       // APIサーバーでembedding抽出
       const ttsResp = await fetch(`${baseUrl}/v1/speakers/register`, {
         method: "POST",
         headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ name, audio_base64 }),
+        body: JSON.stringify({ name: speakerName, audio_base64 }),
       });
       if (!ttsResp.ok) {
         const errText = await ttsResp.text();
@@ -575,29 +580,30 @@ export const handler = async (event) => {
       }
       const result = await ttsResp.json();
 
-      // S3に.pt保存
+      // S3に.pt保存（owner_id/speaker_{name}.pt）
       const ptBuffer = Buffer.from(result.embedding_base64, "base64");
       await s3.send(new PutObjectCommand({
         Bucket: SPEAKERS_BUCKET,
-        Key: `speaker_${name}.pt`,
+        Key: `${owner_id}/speaker_${name}.pt`,
         Body: ptBuffer,
         ContentType: "application/octet-stream",
       }));
 
       // DynamoDB登録
-      const voiceId = `zakicorp-${name}`;
+      const voiceId = `zakicorp-${speakerName}`;
       await ddb.send(new PutCommand({
         TableName: VOICES_TABLE,
         Item: {
           voice_id: voiceId,
           provider: "ZakiCorp",
-          vendor_id: name,
+          owner_id,
+          vendor_id: speakerName,
           label: `${name} (Clone Voice)`,
           created_at: new Date().toISOString(),
         },
       }));
 
-      console.log(`[CustomVoice] Registered: ${voiceId}, pt=${ptBuffer.length}bytes, extraction=${result.extraction_time_ms}ms`);
+      console.log(`[CustomVoice] Registered: ${voiceId}, owner=${owner_id}, pt=${ptBuffer.length}bytes, extraction=${result.extraction_time_ms}ms`);
       return response(200, { voice_id: voiceId, name, extraction_time_ms: result.extraction_time_ms });
     }
 
@@ -605,12 +611,21 @@ export const handler = async (event) => {
     if (method === "DELETE" && path.startsWith("/custom-voices/")) {
       const voiceId = decodeURIComponent(path.split("/")[2]);
       if (!voiceId.startsWith("zakicorp-")) return response(400, { error: "Can only delete ZakiCorp voices" });
-      const name = voiceId.replace("zakicorp-", "");
+
+      const existing = await ddb.send(new GetCommand({
+        TableName: VOICES_TABLE,
+        Key: { voice_id: voiceId },
+      }));
+      if (!existing.Item) return response(404, { error: "Voice not found" });
+      if (existing.Item.owner_id === "system") return response(403, { error: "Cannot delete system voice" });
+
+      const name = existing.Item.vendor_id;
+      const ownerId = existing.Item.owner_id;
 
       // S3から削除
       await s3.send(new DeleteObjectCommand({
         Bucket: SPEAKERS_BUCKET,
-        Key: `speaker_${name}.pt`,
+        Key: `${ownerId}/speaker_${name.replace(`${ownerId}_`, "")}.pt`,
       }));
 
       // DynamoDBから削除

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -559,7 +559,7 @@ export const handler = async (event) => {
     // ---- POST /custom-voices ---- カスタムボイス登録
     if (method === "POST" && path === "/custom-voices") {
       const body = JSON.parse(event.body ?? "{}");
-      const { label, audio_base64, owner_id } = body;
+      const { label, audio_base64, owner_id, mime_type } = body;
       if (!label || !audio_base64) return response(400, { error: "label and audio_base64 are required" });
       if (!owner_id) return response(400, { error: "owner_id is required" });
 
@@ -573,7 +573,7 @@ export const handler = async (event) => {
       const ttsResp = await fetch(`${baseUrl}/v1/speakers/register`, {
         method: "POST",
         headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ name: voiceId, audio_base64 }),
+        body: JSON.stringify({ name: voiceId, audio_base64, mime_type: mime_type || "audio/wav" }),
       });
       if (!ttsResp.ok) {
         const errText = await ttsResp.text();

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -121,10 +121,11 @@ export const handler = async (event) => {
       return response(200, { llms: result.Items ?? [] });
     }
 
-    // ---- GET /voices ---- ボイス一覧取得
+    // ---- GET /voices ---- ボイス一覧取得（ZakiCorpはsystemのみ）
     if (method === "GET" && path === "/voices") {
       const result = await ddb.send(new ScanCommand({ TableName: VOICES_TABLE }));
-      return response(200, { voices: result.Items ?? [] });
+      const voices = (result.Items ?? []).filter(v => v.provider !== "ZakiCorp" || v.owner_id === "system");
+      return response(200, { voices });
     }
 
     // ---- GET /characters ---- キャラクター一覧取得（system + 自分のキャラ）

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -558,21 +558,21 @@ export const handler = async (event) => {
     // ---- POST /custom-voices ---- カスタムボイス登録
     if (method === "POST" && path === "/custom-voices") {
       const body = JSON.parse(event.body ?? "{}");
-      const { name, audio_base64, owner_id } = body;
-      if (!name || !audio_base64) return response(400, { error: "name and audio_base64 are required" });
+      const { label, audio_base64, owner_id } = body;
+      if (!label || !audio_base64) return response(400, { error: "label and audio_base64 are required" });
       if (!owner_id) return response(400, { error: "owner_id is required" });
 
       const apiKey = process.env.ZAKICORP_API_KEY;
       const baseUrl = process.env.ZAKICORP_TTS_URL;
       if (!apiKey || !baseUrl) return response(500, { error: "ZakiCorp TTS not configured" });
 
-      const speakerName = `${owner_id}_${name}`;
+      const voiceId = `${owner_id}_${Date.now()}`;
 
       // APIサーバーでembedding抽出
       const ttsResp = await fetch(`${baseUrl}/v1/speakers/register`, {
         method: "POST",
         headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
-        body: JSON.stringify({ name: speakerName, audio_base64 }),
+        body: JSON.stringify({ name: voiceId, audio_base64 }),
       });
       if (!ttsResp.ok) {
         const errText = await ttsResp.text();
@@ -580,37 +580,60 @@ export const handler = async (event) => {
       }
       const result = await ttsResp.json();
 
-      // S3に.pt保存（owner_id/speaker_{name}.pt）
+      // S3に.pt保存
       const ptBuffer = Buffer.from(result.embedding_base64, "base64");
       await s3.send(new PutObjectCommand({
         Bucket: SPEAKERS_BUCKET,
-        Key: `${owner_id}/speaker_${name}.pt`,
+        Key: `${owner_id}/speaker_${voiceId}.pt`,
         Body: ptBuffer,
         ContentType: "application/octet-stream",
       }));
 
       // DynamoDB登録
-      const voiceId = `zakicorp-${speakerName}`;
       await ddb.send(new PutCommand({
         TableName: VOICES_TABLE,
         Item: {
           voice_id: voiceId,
           provider: "ZakiCorp",
           owner_id,
-          vendor_id: speakerName,
-          label: `${name} (Clone Voice)`,
+          vendor_id: voiceId,
+          label,
           created_at: new Date().toISOString(),
         },
       }));
 
-      console.log(`[CustomVoice] Registered: ${voiceId}, owner=${owner_id}, pt=${ptBuffer.length}bytes, extraction=${result.extraction_time_ms}ms`);
-      return response(200, { voice_id: voiceId, name, extraction_time_ms: result.extraction_time_ms });
+      console.log(`[CustomVoice] Registered: ${voiceId}, owner=${owner_id}, label=${label}, pt=${ptBuffer.length}bytes, extraction=${result.extraction_time_ms}ms`);
+      return response(200, { voice_id: voiceId, label, extraction_time_ms: result.extraction_time_ms });
+    }
+
+    // ---- PUT /custom-voices/{voice_id} ---- カスタムボイス更新（ラベル変更）
+    if (method === "PUT" && path.startsWith("/custom-voices/")) {
+      const voiceId = decodeURIComponent(path.split("/")[2]);
+      const body = JSON.parse(event.body ?? "{}");
+      const { label } = body;
+      if (!label) return response(400, { error: "label is required" });
+
+      const existing = await ddb.send(new GetCommand({
+        TableName: VOICES_TABLE,
+        Key: { voice_id: voiceId },
+      }));
+      if (!existing.Item) return response(404, { error: "Voice not found" });
+      if (existing.Item.owner_id === "system") return response(403, { error: "Cannot edit system voice" });
+
+      await ddb.send(new UpdateCommand({
+        TableName: VOICES_TABLE,
+        Key: { voice_id: voiceId },
+        UpdateExpression: "SET #l = :l",
+        ExpressionAttributeNames: { "#l": "label" },
+        ExpressionAttributeValues: { ":l": label },
+      }));
+
+      return response(200, { voice_id: voiceId, label });
     }
 
     // ---- DELETE /custom-voices/{voice_id} ---- カスタムボイス削除
     if (method === "DELETE" && path.startsWith("/custom-voices/")) {
       const voiceId = decodeURIComponent(path.split("/")[2]);
-      if (!voiceId.startsWith("zakicorp-")) return response(400, { error: "Can only delete ZakiCorp voices" });
 
       const existing = await ddb.send(new GetCommand({
         TableName: VOICES_TABLE,
@@ -619,13 +642,12 @@ export const handler = async (event) => {
       if (!existing.Item) return response(404, { error: "Voice not found" });
       if (existing.Item.owner_id === "system") return response(403, { error: "Cannot delete system voice" });
 
-      const name = existing.Item.vendor_id;
       const ownerId = existing.Item.owner_id;
 
       // S3から削除
       await s3.send(new DeleteObjectCommand({
         Bucket: SPEAKERS_BUCKET,
-        Key: `${ownerId}/speaker_${name.replace(`${ownerId}_`, "")}.pt`,
+        Key: `${ownerId}/speaker_${voiceId}.pt`,
       }));
 
       // DynamoDBから削除

--- a/backend/toytalker-device-setting-lambda/index.mjs
+++ b/backend/toytalker-device-setting-lambda/index.mjs
@@ -1,11 +1,14 @@
 // Node.js 18+ / ESM（index.mjs）
 // Handler: index.handler
-// Env: なし（DynamoDBはIAMロールで接続）
+// Env: ZAKICORP_API_KEY, ZAKICORP_TTS_URL（カスタムボイス登録用）
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand, PutCommand, UpdateCommand, ScanCommand, DeleteCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from "@aws-sdk/client-s3";
 
 const client = new DynamoDBClient({ region: "ap-northeast-1" });
 const ddb = DynamoDBDocumentClient.from(client);
+const s3 = new S3Client({ region: "ap-northeast-1" });
+const SPEAKERS_BUCKET = "toytalker-tts-speakers";
 
 // ---- テーブル定義 ----
 const DEVICES_TABLE        = "toytalker-devices";
@@ -538,6 +541,86 @@ export const handler = async (event) => {
       }
 
       return response(200, { date, conversations });
+    }
+
+    // ---- GET /custom-voices ---- ZakiCorpカスタムボイス一覧
+    if (method === "GET" && path === "/custom-voices") {
+      const result = await ddb.send(new ScanCommand({
+        TableName: VOICES_TABLE,
+        FilterExpression: "provider = :p",
+        ExpressionAttributeValues: { ":p": "ZakiCorp" },
+      }));
+      return response(200, { voices: result.Items ?? [] });
+    }
+
+    // ---- POST /custom-voices ---- カスタムボイス登録
+    if (method === "POST" && path === "/custom-voices") {
+      const body = JSON.parse(event.body ?? "{}");
+      const { name, audio_base64 } = body;
+      if (!name || !audio_base64) return response(400, { error: "name and audio_base64 are required" });
+
+      const apiKey = process.env.ZAKICORP_API_KEY;
+      const baseUrl = process.env.ZAKICORP_TTS_URL;
+      if (!apiKey || !baseUrl) return response(500, { error: "ZakiCorp TTS not configured" });
+
+      // APIサーバーでembedding抽出
+      const ttsResp = await fetch(`${baseUrl}/v1/speakers/register`, {
+        method: "POST",
+        headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ name, audio_base64 }),
+      });
+      if (!ttsResp.ok) {
+        const errText = await ttsResp.text();
+        return response(502, { error: `Embedding extraction failed: ${errText}` });
+      }
+      const result = await ttsResp.json();
+
+      // S3に.pt保存
+      const ptBuffer = Buffer.from(result.embedding_base64, "base64");
+      await s3.send(new PutObjectCommand({
+        Bucket: SPEAKERS_BUCKET,
+        Key: `speaker_${name}.pt`,
+        Body: ptBuffer,
+        ContentType: "application/octet-stream",
+      }));
+
+      // DynamoDB登録
+      const voiceId = `zakicorp-${name}`;
+      await ddb.send(new PutCommand({
+        TableName: VOICES_TABLE,
+        Item: {
+          voice_id: voiceId,
+          provider: "ZakiCorp",
+          vendor_id: name,
+          label: `${name} (Clone Voice)`,
+          created_at: new Date().toISOString(),
+        },
+      }));
+
+      console.log(`[CustomVoice] Registered: ${voiceId}, pt=${ptBuffer.length}bytes, extraction=${result.extraction_time_ms}ms`);
+      return response(200, { voice_id: voiceId, name, extraction_time_ms: result.extraction_time_ms });
+    }
+
+    // ---- DELETE /custom-voices/{voice_id} ---- カスタムボイス削除
+    if (method === "DELETE" && path.startsWith("/custom-voices/")) {
+      const voiceId = decodeURIComponent(path.split("/")[2]);
+      if (!voiceId.startsWith("zakicorp-")) return response(400, { error: "Can only delete ZakiCorp voices" });
+      const name = voiceId.replace("zakicorp-", "");
+
+      // S3から削除
+      await s3.send(new DeleteObjectCommand({
+        Bucket: SPEAKERS_BUCKET,
+        Key: `speaker_${name}.pt`,
+      }));
+
+      // DynamoDBから削除
+      await ddb.send(new DeleteCommand({
+        TableName: VOICES_TABLE,
+        Key: { voice_id: voiceId },
+      }));
+
+      console.log(`[CustomVoice] Deleted: ${voiceId}`);
+      return response(200, { message: `Voice '${voiceId}' deleted` });
     }
 
     return response(404, { error: "Not found" });


### PR DESCRIPTION
## Summary
- ZakiCorp TTS (Qwen3-TTS) をクローンボイスプロバイダーとして追加（ローカルGPU + ngrok経由）
- カスタムボイス管理UI（録音/ファイルアップロードで声を登録、ラベル編集、削除）
- owner_idによるユーザー間のボイス分離
- 相槌Lambda（app/ESP32）にもZakiCorp TTS対応追加
- β版ラベル表示

## Changes
- **Backend**: 5つのLambdaにZakiCorp TTS統合、カスタムボイスCRUD API（POST/PUT/DELETE）、owner_id分離
- **App**: カスタムボイス管理画面（録音・ファイルアップロード・インライン編集・削除）、ボイス選択UIにZakiCorpセクション追加
- **Infra**: CLAUDE.mdにZakiCorp TTS運用手順追加

## Test plan
- [x] 録音によるカスタムボイス作成・再生確認
- [x] ファイルアップロードによるカスタムボイス作成確認
- [x] ボイスラベルのインライン編集・保存確認
- [x] ボイス削除確認
- [x] 異なるユーザー間でボイスが分離されること確認
- [x] キャラクター設定でカスタムボイス選択・会話確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)